### PR TITLE
Remove install packages step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,8 @@ jobs:
 
       - name: Setup Golang
         uses: actions/setup-go@v4
+        with:
+          go-version: '1.13.8'
 
       - name: Install DTLS-Fuzzer
         run: ./install.sh
@@ -236,6 +238,8 @@ jobs:
 
       - name: Setup Golang
         uses: actions/setup-go@v4
+        with:
+          go-version: '1.13.8'
 
       - name: Install DTLS-Fuzzer
         run: ./install.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Setup Golang
+        uses: actions/setup-go@v4
+
       - name: Install DTLS-Fuzzer
         run: ./install.sh
 
@@ -230,6 +233,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Setup Golang
+        uses: actions/setup-go@v4
 
       - name: Install DTLS-Fuzzer
         run: ./install.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
-
       - name: Install DTLS-Fuzzer
         run: ./install.sh
 
@@ -37,13 +30,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
 
       - name: Install DTLS-Fuzzer
         run: ./install.sh
@@ -65,13 +51,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
-
       - name: Install DTLS-Fuzzer
         run: ./install.sh
 
@@ -91,13 +70,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
 
       - name: Install DTLS-Fuzzer
         run: ./install.sh
@@ -119,13 +91,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
-
       - name: Install DTLS-Fuzzer
         run: ./install.sh
 
@@ -145,13 +110,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
 
       - name: Install DTLS-Fuzzer
         run: ./install.sh
@@ -173,13 +131,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
-
       - name: Install DTLS-Fuzzer
         run: ./install.sh
 
@@ -199,13 +150,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
 
       - name: Install DTLS-Fuzzer
         run: ./install.sh
@@ -227,13 +171,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
-
       - name: Install DTLS-Fuzzer
         run: ./install.sh
 
@@ -253,13 +190,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
 
       - name: Install DTLS-Fuzzer
         run: ./install.sh
@@ -281,13 +211,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven golang
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
-
       - name: Install DTLS-Fuzzer
         run: ./install.sh
 
@@ -307,13 +230,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven golang
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
 
       - name: Install DTLS-Fuzzer
         run: ./install.sh
@@ -335,13 +251,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
-
       - name: Install DTLS-Fuzzer
         run: ./install.sh
 
@@ -361,13 +270,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
 
       - name: Install DTLS-Fuzzer
         run: ./install.sh
@@ -390,13 +292,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
-
       - name: Install DTLS-Fuzzer
         run: ./install.sh
 
@@ -416,13 +311,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-11-jdk maven
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-          java -version
 
       - name: Install DTLS-Fuzzer
         run: ./install.sh


### PR DESCRIPTION
Java 11 is default on Ubuntu-latest, so quite a lot of code can be removed. 
(We'll see whether installing maven is still needed.)