### PR TITLE
Prefer ArrayList over LinkedList

### DIFF
--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/ExecuteInputHelper.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/ExecuteInputHelper.java
@@ -13,8 +13,8 @@ import de.rub.nds.tlsattacker.core.state.State;
 import de.rub.nds.tlsattacker.core.state.TlsContext;
 import de.rub.nds.tlsattacker.core.workflow.action.executor.SendMessageHelper;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -64,7 +64,7 @@ public class ExecuteInputHelper {
      * Packs messages/fragments into records ready to be sent.
      */
     public final PackingResult packMessages(List<TlsMessage> messages, State state) {
-        List<AbstractRecord> records = new LinkedList<>();
+        List<AbstractRecord> records = new ArrayList<>();
         for (TlsMessage message : messages) {
             AbstractRecord record = state.getTlsContext().getRecordLayer().getFreshRecord();
             records.add(record);

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/PhasedMapper.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/PhasedMapper.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs.TlsInput;
@@ -81,8 +80,8 @@ public class PhasedMapper extends MapperComposer {
 
         case FRAGMENT_GENERATION:
             // We assume this is DTLS
-            List<FragmentationResult> results = new LinkedList<>();
-            List<TlsMessage> messagesToPack = new LinkedList<>();
+            List<FragmentationResult> results = new ArrayList<>();
+            List<TlsMessage> messagesToPack = new ArrayList<>();
             for (TlsMessage message : unit.getMessages()) {
                 if (message.isHandshakeMessage()) {
                     FragmentationResult result = helper.fragmentMessage((HandshakeMessage) message, state);
@@ -97,16 +96,16 @@ public class PhasedMapper extends MapperComposer {
             break;
 
         case RECORD_GENERATION:
-            List<PackingResult> packingResults = new LinkedList<>();
+            List<PackingResult> packingResults = new ArrayList<>();
             if (!unit.getMessagesToPack().isEmpty()) {
                 ProtocolMessageType msgType = unit.getMessagesToPack().get(0).getProtocolMessageType();
-                List<TlsMessage> messagesInRecord = new LinkedList<>();
+                List<TlsMessage> messagesInRecord = new ArrayList<>();
 
                 for (TlsMessage message : unit.getMessagesToPack()) {
                     if (msgType != message.getProtocolMessageType()) {
                         AbstractRecord record = state.getTlsContext().getRecordLayer().getFreshRecord();
                         packingResults.add(new PackingResult(messagesInRecord, Arrays.asList(record)));
-                        messagesInRecord = new LinkedList<>();
+                        messagesInRecord = new ArrayList<>();
                     }
                     messagesInRecord.add(message);
                 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
@@ -7,7 +7,6 @@ import de.rub.nds.tlsattacker.core.record.AbstractRecord;
 import de.rub.nds.tlsattacker.core.record.Record;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -63,7 +62,7 @@ public class TlsExecutionContext extends ExecutionContextStepped {
     }
 
     public List<AbstractRecord> getAllRecords() {
-        List<AbstractRecord> records = new LinkedList<>();
+        List<AbstractRecord> records = new ArrayList<>();
         getTlsStepContextStream().forEach(tlsStep -> {
             if (tlsStep.getProcessingUnit().getRecordsSent() != null) {
                 records.addAll(tlsStep.getProcessingUnit().getRecordsSent());

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsMessageReceiver.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsMessageReceiver.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
@@ -160,7 +159,7 @@ public class TlsMessageReceiver {
     private List<ProtocolMessage> handleRecordBytes(byte[] recordBytes, ProtocolMessageType type, int epoch,
             TlsContext context) {
         int dataPointer = 0;
-        List<ProtocolMessage> receivedMessages = new LinkedList<>();
+        List<ProtocolMessage> receivedMessages = new ArrayList<>();
 
         while (dataPointer < recordBytes.length) {
             ParserResult result = null;

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/GenericTlsInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/GenericTlsInput.java
@@ -48,7 +48,7 @@ import de.rub.nds.tlsattacker.core.state.State;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElements;
 import java.lang.reflect.Field;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
@@ -146,7 +146,7 @@ public class GenericTlsInput extends DtlsInput {
      * Sets the original value of all mvar fields to null.
      */
     private void stripFields(TlsMessage message) {
-        List<ModifiableVariableHolder> holders = new LinkedList<>();
+        List<ModifiableVariableHolder> holders = new ArrayList<>();
         holders.addAll(message.getAllModifiableVariableHolders());
         for (ModifiableVariableHolder holder : holders) {
             List<Field> fields = holder.getAllModifiableVariableFields();


### PR DESCRIPTION
Most documents say that `ArrayList` is, in most use cases, almost to at least as fast as `LinkedList` and definitely more space-efficient. Therefore, substitute most uses of `LinkedList` with `ArrayList`.