### PR TITLE
Avoid surprising behavior of string.split(String)

### DIFF
--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSulAdapter.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSulAdapter.java
@@ -102,7 +102,7 @@ public class TlsSulAdapter implements SulAdapter {
         } catch (IOException e) {
             throw new TlsSulAdapterException(e);
         }
-        String[] split = resp.split("\\ ");
+        String[] split = resp.split("\\ ", -1);
         if (!split[0].equals(RESP_STARTED)) {
             throw new TlsSulAdapterException(String.format("Received invalid response to %s command", CMD_START));
         }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/outputs/TlsOutputChecker.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/outputs/TlsOutputChecker.java
@@ -126,7 +126,7 @@ public class TlsOutputChecker implements AbstractOutputChecker {
 
     public static KeyExchangeAlgorithm getKeyExchangeAlgorithm(TlsOutput output) {
         if (hasClientKeyExchange(output) || hasServerKeyExchange(output)) {
-            String keyExchange = output.getName().split("_")[0];
+            String keyExchange = output.getName().split("_", -1)[0];
             if (keyExchange.endsWith("DHE")) {
                 keyExchange = keyExchange.substring(0, keyExchange.length()-1);
             }
@@ -136,7 +136,7 @@ public class TlsOutputChecker implements AbstractOutputChecker {
     }
 
     private static String getParameter(TlsOutput output, int idx) {
-        String[] outputSplit = output.getName().split("_");
+        String[] outputSplit = output.getName().split("_", -1);
         return outputSplit[idx];
     }
 }


### PR DESCRIPTION
Set an explicit limit to `-1` to match the behaviour of `Splitter`. More about the issues: https://errorprone.info/bugpattern/StringSplitter