### PR TITLE
Enable error prone compiler plugin

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
                                 <include>*.md</include>
                                 <include>*.sh</include>
                                 <include>*.xml</include>
-                                <include>.mvn/*.xml</include>
+                                <include>.spotbugs/*.xml</include>
                             </includes>
                             <endWithNewline />
                             <trimTrailingWhitespace />

--- a/pom.xml
+++ b/pom.xml
@@ -108,9 +108,9 @@
                     <showWarnings>true</showWarnings>
                     <compilerArgs>
                         <!--arg>-Werror</arg>-->
-                        <arg>-Xlint:unchecked</arg>
+                        <arg>-Xlint:all</arg>
                         <arg>-XDcompilePolicy=simple</arg>
-                        <arg>-Xplugin:ErrorProne -Xep:AddressSelection:OFF -Xep:CatchAndPrintStackTrace:OFF</arg>
+                        <arg>-Xplugin:ErrorProne -Xep:AddressSelection:OFF</arg>
                     </compilerArgs>
                     <annotationProcessorPaths>
                         <path>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <error-prone.version>2.21.1</error-prone.version>
+        <error-prone.version>2.22.0</error-prone.version>
         <jakarta-xml.version>4.0.1</jakarta-xml.version>
         <jcommander.version>1.82</jcommander.version>
         <learnlib.version>0.16.0</learnlib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
+        <error-prone.version>2.21.1</error-prone.version>
         <jakarta-xml.version>4.0.1</jakarta-xml.version>
         <jcommander.version>1.82</jcommander.version>
         <learnlib.version>0.16.0</learnlib.version>
@@ -104,6 +105,20 @@
                 <configuration>
                     <source>11</source>
                     <target>11</target>
+                    <showWarnings>true</showWarnings>
+                    <compilerArgs>
+                        <!--arg>-Werror</arg>-->
+                        <arg>-Xlint:unchecked</arg>
+                        <arg>-XDcompilePolicy=simple</arg>
+                        <arg>-Xplugin:ErrorProne -Xep:AddressSelection:OFF -Xep:CatchAndPrintStackTrace:OFF</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>${error-prone.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>
@@ -168,7 +183,7 @@
                                 <include>*.md</include>
                                 <include>*.sh</include>
                                 <include>*.xml</include>
-                                <include>*/*.xml</include>
+                                <include>.mvn/*.xml</include>
                             </includes>
                             <endWithNewline />
                             <trimTrailingWhitespace />

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSul.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSul.java
@@ -253,7 +253,7 @@ public class TlsSul extends AbstractSul {
 
             output = executeInput(in, executor);
 
-            if (output == AbstractOutput.disabled() || context.getStepContext().isDisabled()) {
+            if (output.equals(AbstractOutput.disabled()) || context.getStepContext().isDisabled()) {
                 // this should lead to a disabled sink state
                 context.disableExecution();
             }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSul.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSul.java
@@ -98,6 +98,7 @@ public class TlsSul extends AbstractSul {
                                     "Causing existing ClientHello waiter thread to terminate by closing the connection.");
                             state.getTlsContext().getTransportHandler().closeConnection();
                         } catch (IOException e) {
+                            LOGGER.error("IOException in TlsSul.run()");
                             e.printStackTrace();
                         }
                     }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSulAdapter.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSulAdapter.java
@@ -57,6 +57,7 @@ public class TlsSulAdapter implements SulAdapter {
                             adapterSocket.close();
                         }
                     } catch (IOException e) {
+                        LOGGER.error("IOException in TlsSulAdapter.run()");
                         e.printStackTrace();
                     }
                 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/ExecuteInputHelper.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/ExecuteInputHelper.java
@@ -16,12 +16,15 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Implements functionality for sending messages/records.
  * This class is analogous to TLS-Attacker's {@link SendMessageHelper} class.
  */
 public class ExecuteInputHelper {
+    private static final Logger LOGGER = LogManager.getLogger();
 
     /**
      * Prepares a TlsMessage; parts were taken from {@link SendMessageHelper}
@@ -83,6 +86,7 @@ public class ExecuteInputHelper {
         try {
             helper.sendRecords(records, state.getTlsContext());
         } catch (IOException e) {
+            LOGGER.error("IOException in ExecuteInputHelper.sendRecords()");
             e.printStackTrace();
         }
     }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/PhasedMapper.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/PhasedMapper.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs.TlsInput;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutputChecker;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutputMapper;
@@ -33,6 +35,7 @@ import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutputMapper
  * Changes in each phase can be implemented by just sub-classing and overriding the executePhase method.
  */
 public class PhasedMapper extends MapperComposer {
+    private static final Logger LOGGER = LogManager.getLogger();
 
     private ExecuteInputHelper helper;
 
@@ -135,6 +138,7 @@ public class PhasedMapper extends MapperComposer {
                     }
 
                 } catch (IOException e) {
+                    LOGGER.error("IOException in record preparation case of PhasedMapper.executePhase()");
                     e.printStackTrace();
                 }
             }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/GenericTlsInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/GenericTlsInput.java
@@ -50,6 +50,8 @@ import jakarta.xml.bind.annotation.XmlElements;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
 
@@ -57,6 +59,8 @@ import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
  * The union of all TLS input messages.
  */
 public class GenericTlsInput extends DtlsInput {
+    private static final Logger LOGGER = LogManager.getLogger();
+
     @XmlElements(value = {
             @XmlElement(type = TlsMessage.class, name = "TlsMessage"),
             @XmlElement(type = CertificateMessage.class, name = "Certificate"),
@@ -157,17 +161,17 @@ public class GenericTlsInput extends DtlsInput {
                 try {
                     mv = (ModifiableVariable) f.get(holder);
                 } catch (IllegalArgumentException | IllegalAccessException ex) {
+                    LOGGER.error("IOException in GenericTlsInput.stripFields()");
                     ex.printStackTrace();
                 }
                 if (mv != null) {
-                    if (mv.getModification() != null
-                            || mv.isCreateRandomModification()) {
+                    if (mv.getModification() != null || mv.isCreateRandomModification()) {
                         mv.setOriginalValue(null);
                     } else {
                         try {
                             f.set(holder, null);
-                        } catch (IllegalArgumentException
-                                | IllegalAccessException ex) {
+                        } catch (IllegalArgumentException | IllegalAccessException ex) {
+                            LOGGER.error("IOException in GenericTlsInput.stripFields()");
                             ex.printStackTrace();
                         }
                     }


### PR DESCRIPTION
Enable all lint checks and correct the remaining error prone issues. (One check that is not satisfied is currently OFF.)