### PR TITLE
Update README.md: fix typo, add missing parameter, and update paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ First we set up the SUT, which is automatically by a `setup_sut.sh` script.
 
 This will create an empty `modules` directory, and a `suts/openssl-1.1.1b` directory.
 
-Then we select an argument file form the `args/openssl` folder.
+Then we select an argument file from the `args/openssl` folder.
 
 We notice there are several argument files to choose from, namely:
 
@@ -155,14 +155,14 @@ A good test is just completing a handshake.
 We supply the argument file, along with a corresponding test from `examples/tests/servers` as parameter.
 We get:
 
-    LD_LIBRARY_PATH=suts/openssl-1.1.1b/ java -jar target/dtls-fuzzer.jar @args/openssl/learn_openssl_server_psk -test examples/tests/servers/psk
+    LD_LIBRARY_PATH=suts/openssl-1.1.1b/ java -Dopenssl.version=1.1.1b -jar target/dtls-fuzzer.jar @args/openssl/learn_openssl_server_psk -test examples/tests/servers/psk
 
 If all goes well, the server should have printed out "This is a hello message", a message we send after completing the handshake.
 Knowing our setup functions, we can now start learning by running:
 
-    LD_LIBRARY_PATH=suts/openssl-1.1.1b/ java -jar target/dtls-fuzzer.jar @args/openssl/learn_openssl_server_psk -eqvQueries 200
+    LD_LIBRARY_PATH=suts/openssl-1.1.1b/ java -Dopenssl.version=1.1.1b -jar target/dtls-fuzzer.jar @args/openssl/learn_openssl_server_psk -eqvQueries 200
 
-We notice that an output directory, `output/openssl-1.1.1b_psk/` for the experiment has been created.
+We notice that an output directory, `output/openssl-1.1.1b_server_psk/` for the experiment has been created.
 We can `ls` this directory to check the current status of the experiment (the number of hypotheses generated...).
 
     ls output/openssl-1.1.1b_server_psk/
@@ -436,7 +436,7 @@ Example for OpenSSL:
 
 With so many paraments, commands can become very long.
 DTLS-Fuzzer uses JCommander to parse arguments, which can also read parameters from a file.
-Go to `experiments/args` for examples of arguments.
+Go to `args` for examples of arguments.
 To supply an argument file to DTLS-Fuzzer provide it as parameter prepended by "@".
 You can also add other explicit arguments to commands (which will overwrite those in the arguments file)
 

--- a/experiments/patches/wolfssl-5.7.6.patch
+++ b/experiments/patches/wolfssl-5.7.6.patch
@@ -1,0 +1,35 @@
+diff -ruN suts/wolfssl-5.7.6/wolfssl/test.h suts/wolfssl-5.7.6_patched/wolfssl/test.h
+--- suts/wolfssl-5.7.6/wolfssl/test.h	2024-12-31 18:58:22.000000000 +0100
++++ suts/wolfssl-5.7.6_patched/wolfssl/test.h	2025-01-29 12:51:57.067887324 +0100
+@@ -1863,12 +1863,10 @@
+             wolfSSL_GetVersion(ssl) != WOLFSSL_DTLSV1_3) {
+         /* test key in hex is 0x1a2b3c4d , in decimal 439,041,101 , we're using
+          * unsigned binary */
+-        key[0] = 0x1a;
+-        key[1] = 0x2b;
+-        key[2] = 0x3c;
+-        key[3] = 0x4d;
++        key[0] = 0x12;
++        key[1] = 0x34;
+ 
+-        ret = 4;   /* length of key in octets or 0 for error */
++        ret = 2;   /* length of key in octets or 0 for error */
+     }
+     else {
+         int i;
+@@ -1908,12 +1906,10 @@
+             wolfSSL_GetVersion(ssl) != WOLFSSL_DTLSV1_3) {
+         /* test key in hex is 0x1a2b3c4d , in decimal 439,041,101 , we're using
+          * unsigned binary */
+-        key[0] = 0x1a;
+-        key[1] = 0x2b;
+-        key[2] = 0x3c;
+-        key[3] = 0x4d;
++        key[0] = 0x12;
++        key[1] = 0x34;
+ 
+-        ret = 4;   /* length of key in octets or 0 for error */
++        ret = 2;   /* length of key in octets or 0 for error */
+     }
+     else {
+         int i;

--- a/setup_sut.sh
+++ b/setup_sut.sh
@@ -125,6 +125,8 @@ readonly WOLFSSL_440="wolfssl-4.4.0"
 readonly WOLFSSL_440_ARCH_URL='https://github.com/wolfSSL/wolfssl/archive/v4.4.0-stable.tar.gz'
 readonly WOLFSSL_471r="wolfssl-4.7.1r"
 readonly WOLFSSL_471r_ARCH_URL='https://github.com/wolfSSL/wolfssl/archive/refs/tags/v4.7.1r.tar.gz'
+readonly WOLFSSL_576="wolfssl-5.7.6"
+readonly WOLFSSL_576_ARCH_URL='https://github.com/wolfSSL/wolfssl/archive/refs/tags/v5.7.6-stable.tar.gz'
 
 # dependencies
 readonly JDK_904="jdk-9.0.4"
@@ -158,7 +160,7 @@ sutvarnames=("CTINYDTLS" "ETINYDTLS" "ETINYDTLS_DEVELOP" \
 "SCANDIUM_OLD" "SCANDIUM_230" "SCANDIUM_262" "SCANDIUM_300_M2" \
 "OPENSSL_111b" "OPENSSL_111c" "OPENSSL_111g" "OPENSSL_111k" "OPENSSL_300" \
 "PIONDTLS_USENIX" "PIONDTLS_152" "PIONDTLS_202" "PIONDTLS_209" \
-"WOLFSSL_400" "WOLFSSL_440" "WOLFSSL_471r")
+"WOLFSSL_400" "WOLFSSL_440" "WOLFSSL_471r" "WOLFSSL_576")
 
 # Alphabetically
 sut_strings=("$CTINYDTLS" "$ETINYDTLS" "$ETINYDTLS_DEVELOP" \
@@ -168,7 +170,7 @@ sut_strings=("$CTINYDTLS" "$ETINYDTLS" "$ETINYDTLS_DEVELOP" \
 "$OPENSSL_111b" "$OPENSSL_111c" "$OPENSSL_111g" "$OPENSSL_111k" "$OPENSSL_300" \
 "$PIONDTLS_USENIX" "$PIONDTLS_152" "$PIONDTLS_202" "$PIONDTLS_209" \
 "$SCANDIUM_OLD" "$SCANDIUM_230" "$SCANDIUM_262" "$SCANDIUM_300_M2" \
-"$WOLFSSL_400" "$WOLFSSL_440" "$WOLFSSL_471r")
+"$WOLFSSL_400" "$WOLFSSL_440" "$WOLFSSL_471r" "$WOLFSSL_576")
 
 # Options for when setting up SUT
 opt_no_patch=0

--- a/trim_model.sh
+++ b/trim_model.sh
@@ -44,7 +44,11 @@ function relabel_and_color() {
         extra=''
     fi
     echo java -jar "$EXP_SCRIPTS_DIR"/dot-trimmer.jar -r "$REPL_FILE" -i "$input_model" -o "$relabelled_model" -t "$other_thr" -pc "$COLOR_FILE" "$extra"
-    java -jar "$EXP_SCRIPTS_DIR"/dot-trimmer.jar -r "$REPL_FILE" -i "$input_model" -o "$relabelled_model" -t "$other_thr" -cp "$COLOR_FILE" "$extra"
+    if [[ -n "$extra" ]]; then
+      java -jar "$EXP_SCRIPTS_DIR"/dot-trimmer.jar -r "$REPL_FILE" -i "$input_model" -o "$relabelled_model" -t "$other_thr" -cp "$COLOR_FILE" "$extra"
+    else
+      java -jar "$EXP_SCRIPTS_DIR"/dot-trimmer.jar -r "$REPL_FILE" -i "$input_model" -o "$relabelled_model" -t "$other_thr" -cp "$COLOR_FILE"
+    fi
 }
 
 # merges (edges of) transitions connecting the same states by placing them on the same arrow in stacked formation


### PR DESCRIPTION
1. fix typo
2. add "-Dopenssl.version=1.1.1b" parameter to java command, otherwise the default "openssl.version=1.1.1k" will be used and fail.
3. update some outdated directory paths