### PR TITLE
Fix trim_model.sh bug when variable "extra" is empty

### DIFF
--- a/trim_model.sh
+++ b/trim_model.sh
@@ -43,8 +43,9 @@ function relabel_and_color() {
         echo "State pruning disabled"
         extra=''
     fi
-    echo java -jar "$EXP_SCRIPTS_DIR"/dot-trimmer.jar -r "$REPL_FILE" -i "$input_model" -o "$relabelled_model" -t "$other_thr" -pc "$COLOR_FILE" "$extra"
-    java -jar "$EXP_SCRIPTS_DIR"/dot-trimmer.jar -r "$REPL_FILE" -i "$input_model" -o "$relabelled_model" -t "$other_thr" -cp "$COLOR_FILE" "$extra"
+    command="java -jar $EXP_SCRIPTS_DIR/dot-trimmer.jar -r $REPL_FILE -i $input_model -o $relabelled_model -t $other_thr -cp $COLOR_FILE $extra"
+    echo $command
+    eval "$command"
 }
 
 # merges (edges of) transitions connecting the same states by placing them on the same arrow in stacked formation


### PR DESCRIPTION
By following the README.md instruction: https://github.com/assist-project/dtls-fuzzer?tab=readme-ov-file#when-things-go-right
I found command `./trim_model.sh --output output/openssl-1.1.1b_server_psk/nicerLearnedModel.dot output/openssl-1.1.1b_server_psk/learnedModel.dot` is not working, and finally I found the problem.

When variable `extra` is empty, "$extra" will introduce two single quotes `''` at the end of java command.
![1732573000072](https://github.com/user-attachments/assets/77478966-55fa-4adf-b9af-2a61cb5f9759)

After fixing the bug, the command works normally, and no more single quotes exist.
![1732573105949](https://github.com/user-attachments/assets/87234657-6457-4eb3-b249-9e74849dcd9c)

