### PR TITLE
Bump org.bouncycastle:bcprov-jdk15on from 1.64 to 1.70

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
         <maven.compiler.target>17</maven.compiler.target>
 
         <!-- Alphabetically sorted -->
+        <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
         <commons.lang3.version>3.17.0</commons.lang3.version>
         <error-prone.version>2.36.0</error-prone.version>
         <jakarta-xml.version>4.0.2</jakarta-xml.version>
@@ -132,7 +133,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.64</version>
+            <version>${bcprov-jdk15on.version}</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>


### PR DESCRIPTION
Slightly better version of #69.

Closes #69.