### PR TITLE
Use generics and the latest version of ProtocolState-Fuzzer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 readonly SCRIPT_DIR
 readonly PATCHES_DIR="$SCRIPT_DIR/experiments/patches"
 
-readonly PROTOCOLSTATEFUZZER_COMMIT="ab19258"
+readonly PROTOCOLSTATEFUZZER_COMMIT="e7a47d5"
 readonly PROTOCOLSTATEFUZZER_REP_URL="https://github.com/protocol-fuzzing/protocol-state-fuzzer.git"
 readonly PROTOCOLSTATEFUZZER_FOLDER="ProtocolState-Fuzzer"
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 readonly SCRIPT_DIR
 readonly PATCHES_DIR="$SCRIPT_DIR/experiments/patches"
 
-readonly PROTOCOLSTATEFUZZER_COMMIT="398c9bc"
+readonly PROTOCOLSTATEFUZZER_COMMIT="ab19258"
 readonly PROTOCOLSTATEFUZZER_REP_URL="https://github.com/protocol-fuzzing/protocol-state-fuzzer.git"
 readonly PROTOCOLSTATEFUZZER_FOLDER="ProtocolState-Fuzzer"
 
@@ -76,7 +76,7 @@ function install_protocolstatefuzzer() {
         (
             cd $PROTOCOLSTATEFUZZER_FOLDER || exit
             echo "Installing ProtocolState-Fuzzer"
-            mvn install -DskipTests
+            ./install.sh
         )
     fi
 }

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 readonly SCRIPT_DIR
 readonly PATCHES_DIR="$SCRIPT_DIR/experiments/patches"
 
-readonly PROTOCOLSTATEFUZZER_COMMIT="e7a47d5"
+readonly PROTOCOLSTATEFUZZER_COMMIT="c5693b1"
 readonly PROTOCOLSTATEFUZZER_REP_URL="https://github.com/protocol-fuzzing/protocol-state-fuzzer.git"
 readonly PROTOCOLSTATEFUZZER_FOLDER="ProtocolState-Fuzzer"
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ readonly SCRIPT_DIR
 readonly PATCHES_DIR="$SCRIPT_DIR/experiments/patches"
 
 
-readonly PROTOCOLSTATEFUZZER_COMMIT="bfc18c3"
+readonly PROTOCOLSTATEFUZZER_COMMIT="b5fe1da"
 readonly PROTOCOLSTATEFUZZER_REP_URL="https://github.com/protocol-fuzzing/protocol-state-fuzzer.git"
 readonly PROTOCOLSTATEFUZZER_FOLDER="ProtocolState-Fuzzer"
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ readonly SCRIPT_DIR
 readonly PATCHES_DIR="$SCRIPT_DIR/experiments/patches"
 
 
-readonly PROTOCOLSTATEFUZZER_COMMIT="2b4e441"
+readonly PROTOCOLSTATEFUZZER_COMMIT="bfc18c3"
 readonly PROTOCOLSTATEFUZZER_REP_URL="https://github.com/protocol-fuzzing/protocol-state-fuzzer.git"
 readonly PROTOCOLSTATEFUZZER_FOLDER="ProtocolState-Fuzzer"
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ readonly SCRIPT_DIR
 readonly PATCHES_DIR="$SCRIPT_DIR/experiments/patches"
 
 
-readonly PROTOCOLSTATEFUZZER_COMMIT="2ce4e392"
+readonly PROTOCOLSTATEFUZZER_COMMIT="2b4e441"
 readonly PROTOCOLSTATEFUZZER_REP_URL="https://github.com/protocol-fuzzing/protocol-state-fuzzer.git"
 readonly PROTOCOLSTATEFUZZER_FOLDER="ProtocolState-Fuzzer"
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 readonly SCRIPT_DIR
 readonly PATCHES_DIR="$SCRIPT_DIR/experiments/patches"
 
-readonly PROTOCOLSTATEFUZZER_COMMIT="c5693b1"
+
+readonly PROTOCOLSTATEFUZZER_COMMIT="2ce4e392"
 readonly PROTOCOLSTATEFUZZER_REP_URL="https://github.com/protocol-fuzzing/protocol-state-fuzzer.git"
 readonly PROTOCOLSTATEFUZZER_FOLDER="ProtocolState-Fuzzer"
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ readonly SCRIPT_DIR
 readonly PATCHES_DIR="$SCRIPT_DIR/experiments/patches"
 
 
-readonly PROTOCOLSTATEFUZZER_COMMIT="b5fe1da"
+readonly PROTOCOLSTATEFUZZER_COMMIT="469ced8"
 readonly PROTOCOLSTATEFUZZER_REP_URL="https://github.com/protocol-fuzzing/protocol-state-fuzzer.git"
 readonly PROTOCOLSTATEFUZZER_FOLDER="ProtocolState-Fuzzer"
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>de.learnlib</groupId>
+            <artifactId>learnlib-api</artifactId>
+            <version>${learnlib.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.protocolfuzzing</groupId>
             <artifactId>protocolstatefuzzer</artifactId>
             <version>1.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <error-prone.version>2.36.0</error-prone.version>
         <jakarta-xml.version>4.0.2</jakarta-xml.version>
         <jcommander.version>1.82</jcommander.version>
-        <learnlib.version>0.17.0</learnlib.version>
+        <learnlib.version>0.18.0</learnlib.version>
         <log4j.version>2.24.3</log4j.version>
         <modifiable-variable.version>4.2.2</modifiable-variable.version>
         <osgi.version>8.1.0</osgi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>de.learnlib</groupId>
-            <artifactId>learnlib-api</artifactId>
-            <version>${learnlib.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.github.protocolfuzzing</groupId>
             <artifactId>protocolstatefuzzer</artifactId>
             <version>1.0.0</version>

--- a/src/main/java/se/uu/it/dtlsfuzzer/Main.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/Main.java
@@ -1,9 +1,12 @@
 package se.uu.it.dtlsfuzzer;
 
+import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.statistics.MealyMachineWrapper;
 import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParser;
 import de.rub.nds.tlsattacker.core.util.ProviderUtil;
 import java.io.IOException;
 import javax.xml.stream.XMLStreamException;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs.TlsInput;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
 
 public class Main {
 
@@ -12,7 +15,7 @@ public class Main {
         MultiBuilder mb = new MultiBuilder();
         // String[] parentLoggers = {Main.class.getPackageName()};
 
-        CommandLineParser commandLineParser = new CommandLineParser(mb, mb, mb, mb);
+        CommandLineParser<MealyMachineWrapper<TlsInput, TlsOutput>> commandLineParser = new CommandLineParser<>(mb, mb, mb, mb);
         // commandLineParser.setExternalParentLoggers(parentLoggers);
         commandLineParser.parse(args);
     }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSul.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSul.java
@@ -41,8 +41,7 @@ import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs.TlsInput;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
 
 /**
- * Implementation of {@link AbstractSul} that works for both clients and
- * servers.
+ * Implementation of {@link AbstractSul} that works for both clients and servers.
  *
  * @author robert, paul
  */
@@ -67,8 +66,7 @@ public class TlsSul implements AbstractSul<TlsInput, TlsOutput, TlsExecutionCont
     private TlsExecutionContext context = null;
 
     /**
-     * Set if the SUL is observed to have terminated the connection (e.g., following
-     * a crash).
+     * Set if the SUL is observed to have terminated the connection (e.g., following a crash).
      */
     private boolean closed = false;
 
@@ -200,8 +198,7 @@ public class TlsSul implements AbstractSul<TlsInput, TlsOutput, TlsExecutionCont
                     try {
                         var firstClientHello = transportHandler.fetchData();
                         receivedClientHello = true;
-                        FirstCachedUdpLayer udpLayer = (FirstCachedUdpLayer) context.getState().getTlsContext()
-                                .getLayerStack().getLowestLayer();
+                        FirstCachedUdpLayer udpLayer = (FirstCachedUdpLayer) context.getState().getTlsContext().getLayerStack().getLowestLayer();
                         udpLayer.setFirstClientHelo(firstClientHello);
                         udpLayer.isFuzzingClient = true;
                     } catch (SocketTimeoutException e) {
@@ -296,16 +293,13 @@ public class TlsSul implements AbstractSul<TlsInput, TlsOutput, TlsExecutionCont
 
     private TlsOutput executeInput(TlsInput in) {
         LOGGER.debug("sent: {}", in.toString());
-        context.getTlsContext()
-                .setTalkingConnectionEndType(context.getTlsContext().getChooser().getConnectionEndType());
+        context.getTlsContext().setTalkingConnectionEndType(context.getTlsContext().getChooser().getConnectionEndType());
         long originalTimeout = context.getTlsContext().getTransportHandler().getTimeout();
         if (in.getExtendedWait() != null) {
             context.getTlsContext().getTransportHandler().setTimeout(originalTimeout + in.getExtendedWait());
         }
-        if (sulConfig.getInputResponseTimeout() != null
-                && sulConfig.getInputResponseTimeout().containsKey(in.getName())) {
-            context.getTlsContext().getTransportHandler()
-                    .setTimeout(sulConfig.getInputResponseTimeout().get(in.getName()));
+        if (sulConfig.getInputResponseTimeout() != null && sulConfig.getInputResponseTimeout().containsKey(in.getName())) {
+            context.getTlsContext().getTransportHandler().setTimeout(sulConfig.getInputResponseTimeout().get(in.getName()));
         }
 
         TlsOutput output = mapperComposer.execute(in, context);
@@ -327,13 +321,11 @@ public class TlsSul implements AbstractSul<TlsInput, TlsOutput, TlsExecutionCont
                 throw new RuntimeException("Could not load configuration file");
             }
         }
-
         return config.createCopy();
     }
 
     /*
-     * Exports the TLS-Attacker configuration file after relevant parameters have
-     * been parsed.
+     * Exports the TLS-Attacker configuration after relevant parameters have been parsed.
      */
     private void exportEffectiveSulConfig(Config config, String path) {
         try {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSul.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSul.java
@@ -92,9 +92,7 @@ public class TlsSul implements AbstractSul<TlsInput, TlsOutput, TlsExecutionCont
      */
     private final TlsSulConfig sulConfig;
 
-    private CleanupTasks cleanupTasks;  /**
-    * Clea
-    */
+    private CleanupTasks cleanupTasks;
 
     private SulAdapter sulAdapter;
 
@@ -145,7 +143,7 @@ public class TlsSul implements AbstractSul<TlsInput, TlsOutput, TlsExecutionCont
         config.getDefaultClientConnection().setUseIpv6(false); // fix NullPointerException
         config.getDefaultServerConnection().setUseIpv6(false); // fix NullPointerException
         State state = new State(config, new WorkflowTrace());
-        context = new TlsExecutionContext((TlsSulConfig) sulConfig, new TlsState(state));
+        context = new TlsExecutionContext(sulConfig, new TlsState(state));
         TransportHandler transportHandler = null;
 
         if (configDelegate.getProtocolVersion().isDTLS()) {
@@ -258,6 +256,7 @@ public class TlsSul implements AbstractSul<TlsInput, TlsOutput, TlsExecutionCont
         }
     }
 
+    @Override
     public TlsOutput step(TlsInput in) {
         context.addStepContext();
 

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSulBuilder.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSulBuilder.java
@@ -37,8 +37,7 @@ public class TlsSulBuilder implements SulBuilder<TlsInput, TlsOutput, TlsExecuti
 
         if (sulConfig.getSulAdapterConfig().getAdapterPort() != null) {
             if (sulAdapter == null) {
-                sulAdapter = new TlsSulAdapter(sulConfig.getSulAdapterConfig(), cleanupTasks,
-                        sulConfig.isFuzzingClient());
+                sulAdapter = new TlsSulAdapter(sulConfig.getSulAdapterConfig(), cleanupTasks, sulConfig.isFuzzingClient());
             }
             tlsSul.setSulAdapter(sulAdapter);
         }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSulBuilder.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSulBuilder.java
@@ -2,13 +2,21 @@ package se.uu.it.dtlsfuzzer.components.sul.core;
 
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.mappers.MapperComposer;
+import com.github.protocolfuzzing.protocolstatefuzzer.utils.CleanupTasks;
 import se.uu.it.dtlsfuzzer.components.sul.core.config.TlsSulConfig;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.DtlsInputMapper;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.DtlsOutputMapper;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsState;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs.TlsInput;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutputBuilder;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutputChecker;
 
-public class TlsSulBuilder implements SulBuilder {
+public class TlsSulBuilder implements SulBuilder<TlsInput, TlsOutput, TlsExecutionContext> {
 
     private TlsSulAdapter sulAdapter = null;
 
@@ -16,14 +24,21 @@ public class TlsSulBuilder implements SulBuilder {
     }
 
     @Override
-    public TlsSul build(SulConfig sulConfig,
-            com.github.protocolfuzzing.protocolstatefuzzer.utils.CleanupTasks cleanupTasks) {
-        DtlsOutputMapper outputMapper = new DtlsOutputMapper(sulConfig.getMapperConfig());
-        TlsSul tlsSul = new TlsSul((TlsSulConfig) sulConfig, sulConfig.getMapperConfig(),
-                new MapperComposer(new DtlsInputMapper(sulConfig.getMapperConfig(), new TlsOutputChecker()), outputMapper), cleanupTasks);
+    public TlsSul build(SulConfig sulConfig, CleanupTasks cleanupTasks) {
+        MapperConfig mapperConfig = sulConfig.getMapperConfig();
+        TlsOutputChecker outputChecker = new TlsOutputChecker();
+        TlsOutputBuilder outputBuilder = new TlsOutputBuilder();
+
+        DtlsOutputMapper outputMapper = new DtlsOutputMapper(mapperConfig, outputBuilder, outputChecker);
+        DtlsInputMapper inputMapper = new DtlsInputMapper(mapperConfig, outputChecker);
+        MapperComposer<TlsInput, TlsOutput, TlsProtocolMessage, TlsExecutionContext, TlsState> mapperComposer = new MapperComposer<>(inputMapper, outputMapper);
+
+        TlsSul tlsSul = new TlsSul((TlsSulConfig) sulConfig, mapperConfig, mapperComposer, cleanupTasks);
+
         if (sulConfig.getSulAdapterConfig().getAdapterPort() != null) {
             if (sulAdapter == null) {
-                sulAdapter = new TlsSulAdapter(sulConfig.getSulAdapterConfig(), cleanupTasks, sulConfig.isFuzzingClient());
+                sulAdapter = new TlsSulAdapter(sulConfig.getSulAdapterConfig(), cleanupTasks,
+                        sulConfig.isFuzzingClient());
             }
             tlsSul.setSulAdapter(sulAdapter);
         }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/config/TlsSulClientConfig.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/config/TlsSulClientConfig.java
@@ -4,7 +4,6 @@ import com.beust.jcommander.ParametersDelegate;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulAdapterConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulClientConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfigStandard;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConnectionConfig;
 import de.rub.nds.tlsattacker.core.config.Config;
 import de.rub.nds.tlsattacker.core.config.delegate.ServerDelegate;
 import de.rub.nds.tlsattacker.core.exceptions.ConfigurationException;
@@ -16,10 +15,6 @@ public class TlsSulClientConfig extends SulClientConfigStandard implements TlsSu
 
     public TlsSulClientConfig() {
         super(new MapperConfigStandard(), new SulAdapterConfigStandard());
-    }
-
-    @Override
-    public void applyDelegate(MapperConnectionConfig config) {
     }
 
     @Override

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/config/TlsSulServerConfig.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/config/TlsSulServerConfig.java
@@ -4,22 +4,17 @@ import com.beust.jcommander.ParametersDelegate;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulAdapterConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulServerConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfigStandard;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConnectionConfig;
 import de.rub.nds.tlsattacker.core.config.Config;
 import de.rub.nds.tlsattacker.core.config.delegate.ClientDelegate;
 import de.rub.nds.tlsattacker.core.exceptions.ConfigurationException;
 
-public class TlsSulServerConfig  extends SulServerConfigStandard implements TlsSulConfig {
+public class TlsSulServerConfig extends SulServerConfigStandard implements TlsSulConfig {
 
     @ParametersDelegate
     private ServerConfigDelegate configDelegate = new ServerConfigDelegate();
 
     public TlsSulServerConfig() {
         super(new MapperConfigStandard(), new SulAdapterConfigStandard());
-    }
-
-    @Override
-    public void applyDelegate(MapperConnectionConfig config) {
     }
 
     @Override

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsInputMapper.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsInputMapper.java
@@ -1,8 +1,6 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutputChecker;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfig;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.mappers.InputMapper;
 import de.rub.nds.tlsattacker.core.layer.LayerConfiguration;
 import de.rub.nds.tlsattacker.core.layer.LayerStack;
@@ -17,19 +15,21 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs.TlsInput;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutputChecker;
 
-public class DtlsInputMapper extends InputMapper {
+public class DtlsInputMapper extends InputMapper<TlsInput, TlsOutput, TlsProtocolMessage, TlsExecutionContext> {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    public DtlsInputMapper(MapperConfig mapperConfig, AbstractOutputChecker outputChecker) {
+    public DtlsInputMapper(MapperConfig mapperConfig, TlsOutputChecker outputChecker) {
         super(mapperConfig, outputChecker);
     }
 
     @Override
-    protected void sendMessage(
-            com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage message,
-            ExecutionContext context) {
+    protected void sendMessage(TlsProtocolMessage message,
+            TlsExecutionContext context) {
         ProtocolMessage protocolMessage = ((TlsProtocolMessage) message).getMessage();
         State state = ((TlsState) context.getState()).getState();
 

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsInputMapper.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsInputMapper.java
@@ -28,10 +28,9 @@ public class DtlsInputMapper extends InputMapper<TlsInput, TlsOutput, TlsProtoco
     }
 
     @Override
-    protected void sendMessage(TlsProtocolMessage message,
-            TlsExecutionContext context) {
-        ProtocolMessage protocolMessage = ((TlsProtocolMessage) message).getMessage();
-        State state = ((TlsState) context.getState()).getState();
+    protected void sendMessage(TlsProtocolMessage message, TlsExecutionContext context) {
+        ProtocolMessage protocolMessage = message.getMessage();
+        State state = context.getState().getState();
 
         // resetting protocol layers and creating a new configuration at each layer
         LayerStack stack = state.getTlsContext().getLayerStack();
@@ -57,7 +56,7 @@ public class DtlsInputMapper extends InputMapper<TlsInput, TlsOutput, TlsProtoco
 
         // updating the execution context with the 'containers' that were produced at
         // each layer
-        ((TlsExecutionContext) context).getStepContext().updateSend(state);
+        context.getStepContext().updateSend(state);
     }
 
     // TODO: Is this code that should be kept or can this be removed?

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsInputMapper.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsInputMapper.java
@@ -36,15 +36,12 @@ public class DtlsInputMapper extends InputMapper<TlsInput, TlsOutput, TlsProtoco
         LayerStack stack = state.getTlsContext().getLayerStack();
         for (ProtocolLayer<?, ?> layer : stack.getLayerList()) {
             layer.clear();
-            layer.setLayerConfiguration(
-                    new SpecificSendLayerConfiguration<>(layer.getLayerType(), Collections.emptyList()));
+            layer.setLayerConfiguration(new SpecificSendLayerConfiguration<>(layer.getLayerType(), Collections.emptyList()));
         }
 
-        // setting a new send configuration at the Message Layer for the message we wish
-        // to send
+        // setting a new send configuration at the Message Layer for the message we wish to send
         MessageLayer messageLayer = (MessageLayer) state.getTlsContext().getLayerStack().getLayer(MessageLayer.class);
-        LayerConfiguration<ProtocolMessage> configuration = new SpecificSendLayerConfiguration<>(
-                ImplementedLayers.MESSAGE, Arrays.asList(protocolMessage));
+        LayerConfiguration<ProtocolMessage> configuration = new SpecificSendLayerConfiguration<>(ImplementedLayers.MESSAGE, Arrays.asList(protocolMessage));
         messageLayer.setLayerConfiguration(configuration);
 
         // performing the actual send of the message
@@ -54,77 +51,7 @@ public class DtlsInputMapper extends InputMapper<TlsInput, TlsOutput, TlsProtoco
             LOGGER.error("Failed to send message {}", protocolMessage.toCompactString());
         }
 
-        // updating the execution context with the 'containers' that were produced at
-        // each layer
+        // updating the execution context with the 'containers' that were produced at each layer
         context.getStepContext().updateSend(state);
     }
-
-    // TODO: Is this code that should be kept or can this be removed?
-    // @Override
-    // protected void sendMessage(
-    // com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage
-    // message,
-    // ExecutionContext context) {
-    // ProtocolMessage<? extends ProtocolMessage<?>> protocolMessage =
-    // ((TlsProtocolMessage) message).getMessage();
-    // State state = ((TlsState) context.getState()).getState();
-    // byte[] bytes;
-    // try {
-    // bytes = generateMessageBytesAdjustContext(protocolMessage, state);
-    // sendMessageBytes(bytes, state, protocolMessage.getProtocolMessageType());
-    // } catch (IOException e) {
-    // context.disableExecution();
-    // LOGGER.info("Error sending message to SUT");
-    // }
-    // }
-    //
-    // public <PM extends ProtocolMessage<PM>> void sendMessage(ProtocolMessage<PM>
-    // message, State state)
-    // throws IOException {
-    // byte[] bytes = generateMessageBytesAdjustContext(message, state);
-    // sendMessageBytes(bytes, state, message.getProtocolMessageType());
-    // if (message.getAdjustContext()) {
-    // ((ProtocolMessageHandler)
-    // message.getHandler(state.getTlsContext())).adjustContextAfterSerialize(message);
-    // }
-    // }
-    //
-    // private void sendMessageBytes(byte[] bytes, State state, ProtocolMessageType
-    // type) throws IOException {
-    // DtlsFragmentLayer dtlsLayer = (DtlsFragmentLayer)
-    // state.getTlsContext().getLayerStack()
-    // .getLayer(DtlsFragmentLayer.class);
-    // SpecificSendLayerConfiguration<DataContainer<DtlsHandshakeMessageFragment,
-    // TlsContext>> fragmentLayerConfig = new SpecificSendLayerConfiguration<>(
-    // ImplementedLayers.DTLS_FRAGMENT, Collections.emptyList());
-    // dtlsLayer.setLayerConfiguration(fragmentLayerConfig);
-    // RecordLayer recordLayer = (RecordLayer)
-    // state.getTlsContext().getLayerStack().getLayer(RecordLayer.class);
-    // SpecificSendLayerConfiguration<DataContainer<Record, TlsContext>>
-    // recordLayerConfig = new SpecificSendLayerConfiguration<>(
-    // ImplementedLayers.RECORD, Collections.emptyList());
-    // RecordLayerHint recordLayerHint = new RecordLayerHint(type);
-    // recordLayer.setLayerConfiguration(recordLayerConfig);
-    // dtlsLayer.sendData(recordLayerHint, bytes);
-    // }
-    //
-    // private final <T extends ProtocolMessage<?>> byte[]
-    // generateMessageBytesAdjustContext(ProtocolMessage<T> message,
-    // State state) throws IOException {
-    // ProtocolMessagePreparator<? extends ProtocolMessage<?>> preparator = message
-    // .getPreparator(state.getTlsContext());
-    // preparator.prepare();
-    // preparator.afterPrepare();
-    // ProtocolMessageSerializer<? extends ProtocolMessage<?>> serializer = message
-    // .getSerializer(state.getTlsContext());
-    // byte[] completeMessage = serializer.serialize();
-    // message.setCompleteResultingMessage(completeMessage);
-    // ProtocolMessageHandler handler = message.getHandler(state.getTlsContext());
-    // handler.updateDigest(message, true);
-    // if (message.getAdjustContext()) {
-    // handler.adjustContext(message);
-    // }
-    // message.setCompleteResultingMessage(completeMessage);
-    // return completeMessage;
-    // }
 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsInputMapper.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsInputMapper.java
@@ -35,14 +35,17 @@ public class DtlsInputMapper extends InputMapper<TlsInput, TlsOutput, TlsProtoco
 
         // resetting protocol layers and creating a new configuration at each layer
         LayerStack stack = state.getTlsContext().getLayerStack();
-        for (ProtocolLayer<?,?> layer : stack.getLayerList()) {
+        for (ProtocolLayer<?, ?> layer : stack.getLayerList()) {
             layer.clear();
-            layer.setLayerConfiguration(new SpecificSendLayerConfiguration<>(layer.getLayerType(), Collections.emptyList()));
+            layer.setLayerConfiguration(
+                    new SpecificSendLayerConfiguration<>(layer.getLayerType(), Collections.emptyList()));
         }
 
-        // setting a new send configuration at the Message Layer for the message we wish to send
+        // setting a new send configuration at the Message Layer for the message we wish
+        // to send
         MessageLayer messageLayer = (MessageLayer) state.getTlsContext().getLayerStack().getLayer(MessageLayer.class);
-        LayerConfiguration<ProtocolMessage> configuration = new SpecificSendLayerConfiguration<>(ImplementedLayers.MESSAGE, Arrays.asList(protocolMessage));
+        LayerConfiguration<ProtocolMessage> configuration = new SpecificSendLayerConfiguration<>(
+                ImplementedLayers.MESSAGE, Arrays.asList(protocolMessage));
         messageLayer.setLayerConfiguration(configuration);
 
         // performing the actual send of the message
@@ -52,66 +55,77 @@ public class DtlsInputMapper extends InputMapper<TlsInput, TlsOutput, TlsProtoco
             LOGGER.error("Failed to send message {}", protocolMessage.toCompactString());
         }
 
-        // updating the execution context with the 'containers' that were produced at each layer
+        // updating the execution context with the 'containers' that were produced at
+        // each layer
         ((TlsExecutionContext) context).getStepContext().updateSend(state);
     }
 
-//
-//	@Override
-//	protected void sendMessage(
-//			com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage message,
-//			ExecutionContext context) {
-//		ProtocolMessage<? extends ProtocolMessage<?>> protocolMessage = ((TlsProtocolMessage) message).getMessage();
-//		State state = ((TlsState) context.getState()).getState();
-//		byte[] bytes;
-//		try {
-//			bytes = generateMessageBytesAdjustContext(protocolMessage, state);
-//			sendMessageBytes(bytes, state, protocolMessage.getProtocolMessageType());
-//		} catch (IOException e) {
-//			context.disableExecution();
-//			LOGGER.info("Error sending message to SUT");
-//		}
-//	}
-//
-//	public <PM extends ProtocolMessage<PM>> void sendMessage(ProtocolMessage<PM> message, State state)
-//			throws IOException {
-//		byte[] bytes = generateMessageBytesAdjustContext(message, state);
-//		sendMessageBytes(bytes, state, message.getProtocolMessageType());
-//		if (message.getAdjustContext()) {
-//			((ProtocolMessageHandler) message.getHandler(state.getTlsContext())).adjustContextAfterSerialize(message);
-//		}
-//	}
-//
-//	private void sendMessageBytes(byte[] bytes, State state, ProtocolMessageType type) throws IOException {
-//		DtlsFragmentLayer dtlsLayer = (DtlsFragmentLayer) state.getTlsContext().getLayerStack()
-//				.getLayer(DtlsFragmentLayer.class);
-//		SpecificSendLayerConfiguration<DataContainer<DtlsHandshakeMessageFragment, TlsContext>> fragmentLayerConfig = new SpecificSendLayerConfiguration<>(
-//				ImplementedLayers.DTLS_FRAGMENT, Collections.emptyList());
-//		dtlsLayer.setLayerConfiguration(fragmentLayerConfig);
-//		RecordLayer recordLayer = (RecordLayer) state.getTlsContext().getLayerStack().getLayer(RecordLayer.class);
-//		SpecificSendLayerConfiguration<DataContainer<Record, TlsContext>> recordLayerConfig = new SpecificSendLayerConfiguration<>(
-//				ImplementedLayers.RECORD, Collections.emptyList());
-//		RecordLayerHint recordLayerHint = new RecordLayerHint(type);
-//		recordLayer.setLayerConfiguration(recordLayerConfig);
-//		dtlsLayer.sendData(recordLayerHint, bytes);
-//	}
-//
-//	private final <T extends ProtocolMessage<?>> byte[] generateMessageBytesAdjustContext(ProtocolMessage<T> message,
-//			State state) throws IOException {
-//		ProtocolMessagePreparator<? extends ProtocolMessage<?>> preparator = message
-//				.getPreparator(state.getTlsContext());
-//		preparator.prepare();
-//		preparator.afterPrepare();
-//		ProtocolMessageSerializer<? extends ProtocolMessage<?>> serializer = message
-//				.getSerializer(state.getTlsContext());
-//		byte[] completeMessage = serializer.serialize();
-//		message.setCompleteResultingMessage(completeMessage);
-//		ProtocolMessageHandler handler = message.getHandler(state.getTlsContext());
-//		handler.updateDigest(message, true);
-//		if (message.getAdjustContext()) {
-//			handler.adjustContext(message);
-//		}
-//		message.setCompleteResultingMessage(completeMessage);
-//		return completeMessage;
-//	}
+    // TODO: Is this code that should be kept or can this be removed?
+    // @Override
+    // protected void sendMessage(
+    // com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage
+    // message,
+    // ExecutionContext context) {
+    // ProtocolMessage<? extends ProtocolMessage<?>> protocolMessage =
+    // ((TlsProtocolMessage) message).getMessage();
+    // State state = ((TlsState) context.getState()).getState();
+    // byte[] bytes;
+    // try {
+    // bytes = generateMessageBytesAdjustContext(protocolMessage, state);
+    // sendMessageBytes(bytes, state, protocolMessage.getProtocolMessageType());
+    // } catch (IOException e) {
+    // context.disableExecution();
+    // LOGGER.info("Error sending message to SUT");
+    // }
+    // }
+    //
+    // public <PM extends ProtocolMessage<PM>> void sendMessage(ProtocolMessage<PM>
+    // message, State state)
+    // throws IOException {
+    // byte[] bytes = generateMessageBytesAdjustContext(message, state);
+    // sendMessageBytes(bytes, state, message.getProtocolMessageType());
+    // if (message.getAdjustContext()) {
+    // ((ProtocolMessageHandler)
+    // message.getHandler(state.getTlsContext())).adjustContextAfterSerialize(message);
+    // }
+    // }
+    //
+    // private void sendMessageBytes(byte[] bytes, State state, ProtocolMessageType
+    // type) throws IOException {
+    // DtlsFragmentLayer dtlsLayer = (DtlsFragmentLayer)
+    // state.getTlsContext().getLayerStack()
+    // .getLayer(DtlsFragmentLayer.class);
+    // SpecificSendLayerConfiguration<DataContainer<DtlsHandshakeMessageFragment,
+    // TlsContext>> fragmentLayerConfig = new SpecificSendLayerConfiguration<>(
+    // ImplementedLayers.DTLS_FRAGMENT, Collections.emptyList());
+    // dtlsLayer.setLayerConfiguration(fragmentLayerConfig);
+    // RecordLayer recordLayer = (RecordLayer)
+    // state.getTlsContext().getLayerStack().getLayer(RecordLayer.class);
+    // SpecificSendLayerConfiguration<DataContainer<Record, TlsContext>>
+    // recordLayerConfig = new SpecificSendLayerConfiguration<>(
+    // ImplementedLayers.RECORD, Collections.emptyList());
+    // RecordLayerHint recordLayerHint = new RecordLayerHint(type);
+    // recordLayer.setLayerConfiguration(recordLayerConfig);
+    // dtlsLayer.sendData(recordLayerHint, bytes);
+    // }
+    //
+    // private final <T extends ProtocolMessage<?>> byte[]
+    // generateMessageBytesAdjustContext(ProtocolMessage<T> message,
+    // State state) throws IOException {
+    // ProtocolMessagePreparator<? extends ProtocolMessage<?>> preparator = message
+    // .getPreparator(state.getTlsContext());
+    // preparator.prepare();
+    // preparator.afterPrepare();
+    // ProtocolMessageSerializer<? extends ProtocolMessage<?>> serializer = message
+    // .getSerializer(state.getTlsContext());
+    // byte[] completeMessage = serializer.serialize();
+    // message.setCompleteResultingMessage(completeMessage);
+    // ProtocolMessageHandler handler = message.getHandler(state.getTlsContext());
+    // handler.updateDigest(message, true);
+    // if (message.getAdjustContext()) {
+    // handler.adjustContext(message);
+    // }
+    // message.setCompleteResultingMessage(completeMessage);
+    // return completeMessage;
+    // }
 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsOutputMapper.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsOutputMapper.java
@@ -56,10 +56,8 @@ public class DtlsOutputMapper extends OutputMapper<TlsOutput, TlsProtocolMessage
         messageLayer.getLayerResult().getUsedContainers().stream().forEach(m -> messages.add(m));
 
         TlsOutput output = extractOutput(messages);
-        // updating the execution context with the 'containers' that were produced at
-        // each layer
-        context.getStepContext()
-                .updateReceive(context.getState().getState());
+        // updating the execution context with the 'containers' that were produced at each layer
+        context.getStepContext().updateReceive(context.getState().getState());
         return output;
     }
 
@@ -73,8 +71,8 @@ public class DtlsOutputMapper extends OutputMapper<TlsOutput, TlsProtocolMessage
             List<ProtocolMessage> tlsMessages = receivedMessages.stream().collect(Collectors.toList());
             List<String> abstractMessageStrings = extractAbstractMessageStrings(tlsMessages);
             String abstractOutput = toAbstractOutputString(abstractMessageStrings);
-            List<TlsProtocolMessage> tlsProtocolMessages = tlsMessages
-                    .stream().map(m -> new TlsProtocolMessage(m)).collect(Collectors.toList());
+            List<TlsProtocolMessage> tlsProtocolMessages =
+                tlsMessages.stream().map(m -> new TlsProtocolMessage(m)).collect(Collectors.toList());
 
             return new TlsOutput(abstractOutput, tlsProtocolMessages);
         }
@@ -173,8 +171,7 @@ public class DtlsOutputMapper extends OutputMapper<TlsOutput, TlsProtocolMessage
             case ECDSA:
                 return "ECDSA";
             default:
-                throw new NotImplementedException(
-                        "Signature algorithm mapping not implemented for: " + certType.name());
+                throw new NotImplementedException("Signature algorithm mapping not implemented for: " + certType.name());
         }
     }
 

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsOutputMapper.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsOutputMapper.java
@@ -31,7 +31,7 @@ public class DtlsOutputMapper extends OutputMapper<TlsOutput, TlsProtocolMessage
 
     @Override
     public TlsOutput receiveOutput(TlsExecutionContext context) {
-        TlsContext tlsContext = ((TlsExecutionContext) context).getState().getTlsContext();
+        TlsContext tlsContext = context.getState().getTlsContext();
         try {
             if (tlsContext.getTransportHandler().isClosed()) {
                 return socketClosed();
@@ -58,8 +58,8 @@ public class DtlsOutputMapper extends OutputMapper<TlsOutput, TlsProtocolMessage
         TlsOutput output = extractOutput(messages);
         // updating the execution context with the 'containers' that were produced at
         // each layer
-        ((TlsExecutionContext) context).getStepContext()
-                .updateReceive(((TlsExecutionContext) context).getState().getState());
+        context.getStepContext()
+                .updateReceive(context.getState().getState());
         return output;
     }
 

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsOutputMapper.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/DtlsOutputMapper.java
@@ -43,7 +43,7 @@ public class DtlsOutputMapper extends OutputMapper<TlsOutput, TlsProtocolMessage
 
         // resetting protocol stack layers and creating configurations for each layer
         List<LayerConfiguration<?>> layerConfigs = new ArrayList<>(tlsContext.getLayerStack().getLayerList().size());
-        for (ProtocolLayer<?,?> layer : tlsContext.getLayerStack().getLayerList()) {
+        for (ProtocolLayer<?, ?> layer : tlsContext.getLayerStack().getLayerList()) {
             layer.clear();
             GenericReceiveLayerConfiguration receiveConfig = new GenericReceiveLayerConfiguration(layer.getLayerType());
             layerConfigs.add(receiveConfig);
@@ -55,9 +55,11 @@ public class DtlsOutputMapper extends OutputMapper<TlsOutput, TlsProtocolMessage
         List<ProtocolMessage> messages = new ArrayList<>(messageLayer.getLayerResult().getUsedContainers().size());
         messageLayer.getLayerResult().getUsedContainers().stream().forEach(m -> messages.add(m));
 
-        // updating the execution context with the 'containers' that were produced at each layer
-        ((TlsExecutionContext) context).getStepContext().updateReceive(((TlsExecutionContext) context).getState().getState());
         TlsOutput output = extractOutput(messages);
+        // updating the execution context with the 'containers' that were produced at
+        // each layer
+        ((TlsExecutionContext) context).getStepContext()
+                .updateReceive(((TlsExecutionContext) context).getState().getState());
         return output;
     }
 
@@ -71,8 +73,8 @@ public class DtlsOutputMapper extends OutputMapper<TlsOutput, TlsProtocolMessage
             List<ProtocolMessage> tlsMessages = receivedMessages.stream().collect(Collectors.toList());
             List<String> abstractMessageStrings = extractAbstractMessageStrings(tlsMessages);
             String abstractOutput = toAbstractOutputString(abstractMessageStrings);
-            List<com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage> tlsProtocolMessages =
-            tlsMessages.stream().map(m -> new TlsProtocolMessage(m)).collect(Collectors.toList());
+            List<TlsProtocolMessage> tlsProtocolMessages = tlsMessages
+                    .stream().map(m -> new TlsProtocolMessage(m)).collect(Collectors.toList());
 
             return new TlsOutput(abstractOutput, tlsProtocolMessages);
         }
@@ -171,7 +173,8 @@ public class DtlsOutputMapper extends OutputMapper<TlsOutput, TlsProtocolMessage
             case ECDSA:
                 return "ECDSA";
             default:
-                throw new NotImplementedException("Signature algorithm mapping not implemented for: " + certType.name());
+                throw new NotImplementedException(
+                        "Signature algorithm mapping not implemented for: " + certType.name());
         }
     }
 

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
@@ -46,14 +46,6 @@ public class TlsExecutionContext extends ExecutionContextStepped<TlsInput, TlsOu
      * {@inheritDoc}
      */
     @Override
-    public void addStepContext() {
-        stepContexts.add(new TlsStepContext(stepContexts.size()));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public TlsStepContext getStepContext() {
         return super.getStepContext();
     }
@@ -70,7 +62,7 @@ public class TlsExecutionContext extends ExecutionContextStepped<TlsInput, TlsOu
      * Provides a fresh ordered Stream of TlsStepContext elements.
      */
     public Stream<TlsStepContext> getTlsStepContextStream() {
-        return stepContexts.stream().map(step -> step);  // XXX: Is map needed here?
+        return stepContexts.stream();
     }
 
     public List<Record> getAllRecords() {
@@ -126,10 +118,13 @@ public class TlsExecutionContext extends ExecutionContextStepped<TlsInput, TlsOu
         return writeRecordNumberEpoch0;
     }
 
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected TlsStepContext buildStepContext() {
-        // FIXME: Write implementation
-        throw new UnsupportedOperationException("Unimplemented method 'buildStepContext'");
+        return new TlsStepContext(stepContexts.size());
     }
 
     /*

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
@@ -27,11 +27,11 @@ public class TlsExecutionContext extends ExecutionContextStepped<TlsInput, TlsOu
 
     @Override
     public TlsState getState() {
-        return (TlsState) state;
+        return state;
     }
 
     public TlsContext getTlsContext() {
-        return ((TlsState) state).getTlsContext();
+        return state.getTlsContext();
     }
 
     public TlsSulConfig getTlsSulConfig() {
@@ -55,7 +55,7 @@ public class TlsExecutionContext extends ExecutionContextStepped<TlsInput, TlsOu
      */
     @Override
     public TlsStepContext getStepContext() {
-        return (TlsStepContext) super.getStepContext();
+        return super.getStepContext();
     }
 
     /**
@@ -63,7 +63,7 @@ public class TlsExecutionContext extends ExecutionContextStepped<TlsInput, TlsOu
      */
     @Override
     public TlsStepContext getStepContext(int index) {
-        return (TlsStepContext) super.getStepContext(index);
+        return super.getStepContext(index);
     }
 
     /**

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
@@ -133,10 +133,10 @@ public class TlsExecutionContext extends ExecutionContextStepped<TlsInput, TlsOu
     }
 
     /*
-     * public Long incrementWriteRecordNumberEpoch0() {
-     * Long old = writeRecordNumberEpoch0;
-     * writeRecordNumberEpoch0++;
-     * return old;
-     * }
-     */
+      public Long incrementWriteRecordNumberEpoch0() {
+        Long old = writeRecordNumberEpoch0;
+        writeRecordNumberEpoch0++;
+        return old;
+      }
+    */
 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
@@ -70,7 +70,7 @@ public class TlsExecutionContext extends ExecutionContextStepped<TlsInput, TlsOu
      * Provides a fresh ordered Stream of TlsStepContext elements.
      */
     public Stream<TlsStepContext> getTlsStepContextStream() {
-        return stepContexts.stream().map(step -> (TlsStepContext) step);
+        return stepContexts.stream().map(step -> step);  // XXX: Is map needed here?
     }
 
     public List<Record> getAllRecords() {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
@@ -11,8 +11,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import se.uu.it.dtlsfuzzer.components.sul.core.config.TlsSulConfig;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs.TlsInput;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
 
-public class TlsExecutionContext extends ExecutionContextStepped {
+public class TlsExecutionContext extends ExecutionContextStepped<TlsInput, TlsOutput, TlsState, TlsStepContext> {
 
     private Integer renegotiationIndex = 0;
     private Long writeRecordNumberEpoch0 = null;
@@ -122,6 +124,12 @@ public class TlsExecutionContext extends ExecutionContextStepped {
 
     public Long getWriteRecordNumberEpoch0() {
         return writeRecordNumberEpoch0;
+    }
+
+    @Override
+    protected TlsStepContext buildStepContext() {
+        // FIXME: Write implementation
+        throw new UnsupportedOperationException("Unimplemented method 'buildStepContext'");
     }
 
     /*

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsExecutionContext.java
@@ -133,10 +133,10 @@ public class TlsExecutionContext extends ExecutionContextStepped<TlsInput, TlsOu
     }
 
     /*
-      public Long incrementWriteRecordNumberEpoch0() {
-        Long old = writeRecordNumberEpoch0;
-        writeRecordNumberEpoch0++;
-        return old;
-      }
-    */
+     * public Long incrementWriteRecordNumberEpoch0() {
+     * Long old = writeRecordNumberEpoch0;
+     * writeRecordNumberEpoch0++;
+     * return old;
+     * }
+     */
 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsProtocolMessage.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsProtocolMessage.java
@@ -5,7 +5,7 @@ import de.rub.nds.tlsattacker.core.protocol.ProtocolMessage;
 /**
  * The ProtocolMessage is a wrapper around a TLS-Attacker ProtocolMessage.
  */
-public class TlsProtocolMessage implements com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage {
+public class TlsProtocolMessage {
 
     private final ProtocolMessage message;
 

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsState.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsState.java
@@ -3,7 +3,7 @@ package se.uu.it.dtlsfuzzer.components.sul.mapper;
 import de.rub.nds.tlsattacker.core.layer.context.TlsContext;
 import de.rub.nds.tlsattacker.core.state.State;
 
-public class TlsState implements com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.State {
+public class TlsState {
     private State state;
 
     public TlsState(State state) {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsStepContext.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsStepContext.java
@@ -82,7 +82,7 @@ public class TlsStepContext extends StepContext<TlsInput, TlsOutput> {
 
     @Override
     public TlsInput getInput() {
-        return (TlsInput) input;
+        return input;
     }
 
     public List<Pair<ProtocolMessage, Record>> getReceivedMessageRecordPairs() {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsStepContext.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsStepContext.java
@@ -60,7 +60,6 @@ public class TlsStepContext extends StepContext<TlsInput, TlsOutput> {
         return receivedMessages;
     }
 
-
     public List<ProtocolMessage> getSentMessages() {
         return sentMessages;
     }
@@ -86,9 +85,10 @@ public class TlsStepContext extends StepContext<TlsInput, TlsOutput> {
         return (TlsInput) input;
     }
 
-    public  List<Pair<ProtocolMessage, Record>> getReceivedMessageRecordPairs() {
+    public List<Pair<ProtocolMessage, Record>> getReceivedMessageRecordPairs() {
         assert receivedRecords.size() == receivedMessages.size();
-        return IntStream.range(0, receivedMessages.size()).boxed().map(i ->
-        Pair.<ProtocolMessage, Record>of(receivedMessages.get(i), receivedRecords.get(i))).collect(Collectors.toList());
+        return IntStream.range(0, receivedMessages.size()).boxed()
+                .map(i -> Pair.<ProtocolMessage, Record>of(receivedMessages.get(i), receivedRecords.get(i)))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsStepContext.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/TlsStepContext.java
@@ -14,9 +14,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.tuple.Pair;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs.TlsInput;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
 
-
-public class TlsStepContext extends StepContext {
+public class TlsStepContext extends StepContext<TlsInput, TlsOutput> {
 
     private List<ProtocolMessage> sentMessages;
     private List<DtlsHandshakeMessageFragment> sentFragments;

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/AlertInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/AlertInput.java
@@ -22,7 +22,7 @@ public class AlertInput extends DtlsInput {
     @Override
     public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         AlertMessage alert = new AlertMessage();
-        alert.setConfig(new byte [] {level.getValue(), description.getValue()});
+        alert.setConfig(new byte[] { level.getValue(), description.getValue() });
         return new TlsProtocolMessage(alert);
     }
 

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/AlertInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/AlertInput.java
@@ -1,10 +1,10 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.tlsattacker.core.constants.AlertDescription;
 import de.rub.nds.tlsattacker.core.constants.AlertLevel;
 import de.rub.nds.tlsattacker.core.protocol.message.AlertMessage;
 import jakarta.xml.bind.annotation.XmlAttribute;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 public class AlertInput extends DtlsInput {
@@ -20,7 +20,7 @@ public class AlertInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         AlertMessage alert = new AlertMessage();
         alert.setConfig(new byte [] {level.getValue(), description.getValue()});
         return new TlsProtocolMessage(alert);

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ApplicationInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ApplicationInput.java
@@ -1,8 +1,8 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.tlsattacker.core.protocol.message.ApplicationMessage;
 import jakarta.xml.bind.DatatypeConverter;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 public class ApplicationInput extends DtlsInput {
@@ -12,8 +12,9 @@ public class ApplicationInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
-        ApplicationMessage appMessage = new ApplicationMessage(DatatypeConverter.parseHexBinary("5468697320697320612068656c6c6f206d65737361676521"));
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
+        ApplicationMessage appMessage = new ApplicationMessage(
+                DatatypeConverter.parseHexBinary("5468697320697320612068656c6c6f206d65737361676521"));
 
         return new TlsProtocolMessage(appMessage);
     }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ApplicationInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ApplicationInput.java
@@ -13,8 +13,7 @@ public class ApplicationInput extends DtlsInput {
 
     @Override
     public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
-        ApplicationMessage appMessage = new ApplicationMessage(
-                DatatypeConverter.parseHexBinary("5468697320697320612068656c6c6f206d65737361676521"));
+        ApplicationMessage appMessage = new ApplicationMessage(DatatypeConverter.parseHexBinary("5468697320697320612068656c6c6f206d65737361676521"));
 
         return new TlsProtocolMessage(appMessage);
     }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/CertificateInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/CertificateInput.java
@@ -1,9 +1,9 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.tlsattacker.core.protocol.message.CertificateMessage;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Collections;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 public class CertificateInput extends DtlsInput {
@@ -15,7 +15,7 @@ public class CertificateInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         CertificateMessage message = new CertificateMessage();
         if (empty) {
             message.setCertificateEntryList(Collections.emptyList());

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/CertificateInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/CertificateInput.java
@@ -8,7 +8,7 @@ import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 public class CertificateInput extends DtlsInput {
 
-    @XmlAttribute(name="empty", required=false)
+    @XmlAttribute(name = "empty", required = false)
     private boolean empty = false;
 
     public CertificateInput() {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/CertificateRequestInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/CertificateRequestInput.java
@@ -1,11 +1,11 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.modifiablevariable.bytearray.ByteArrayModificationFactory;
 import de.rub.nds.modifiablevariable.bytearray.ModifiableByteArray;
 import de.rub.nds.tlsattacker.core.constants.ClientCertificateType;
 import de.rub.nds.tlsattacker.core.protocol.message.CertificateRequestMessage;
 import jakarta.xml.bind.annotation.XmlAttribute;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 public class CertificateRequestInput extends DtlsInput {
@@ -23,7 +23,7 @@ public class CertificateRequestInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         CertificateRequestMessage message = new CertificateRequestMessage();
         if (certificateType != null) {
             ModifiableByteArray ctbyte = new ModifiableByteArray();

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/CertificateRequestInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/CertificateRequestInput.java
@@ -10,7 +10,7 @@ import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 public class CertificateRequestInput extends DtlsInput {
 
-    @XmlAttribute(name="certificate", required=true)
+    @XmlAttribute(name = "certificate", required = true)
     ClientCertificateType certificateType;
 
     public CertificateRequestInput() {
@@ -27,7 +27,8 @@ public class CertificateRequestInput extends DtlsInput {
         CertificateRequestMessage message = new CertificateRequestMessage();
         if (certificateType != null) {
             ModifiableByteArray ctbyte = new ModifiableByteArray();
-            ctbyte.setModification(ByteArrayModificationFactory.explicitValue(new byte[] {certificateType.getValue()}));
+            ctbyte.setModification(
+                    ByteArrayModificationFactory.explicitValue(new byte[] { certificateType.getValue() }));
             message.setClientCertificateTypes(ctbyte);
         }
         return new TlsProtocolMessage(message);

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/CertificateRequestInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/CertificateRequestInput.java
@@ -27,8 +27,7 @@ public class CertificateRequestInput extends DtlsInput {
         CertificateRequestMessage message = new CertificateRequestMessage();
         if (certificateType != null) {
             ModifiableByteArray ctbyte = new ModifiableByteArray();
-            ctbyte.setModification(
-                    ByteArrayModificationFactory.explicitValue(new byte[] { certificateType.getValue() }));
+            ctbyte.setModification(ByteArrayModificationFactory.explicitValue(new byte[] { certificateType.getValue() }));
             message.setClientCertificateTypes(ctbyte);
         }
         return new TlsProtocolMessage(message);

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ChangeCipherSpecInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ChangeCipherSpecInput.java
@@ -32,11 +32,9 @@ public class ChangeCipherSpecInput extends DtlsInput {
 
     @Override
     public void postSendDtlsUpdate(TlsExecutionContext context) {
-        // TLS-Attacker instantiates non-null ciphers even when the pre-master secret
-        // has not been yet negotiated.
+        // TLS-Attacker instantiates non-null ciphers even when the pre-master secret has not been yet negotiated.
         // Here, we replace the ciphers instantiated in such cases by null ciphers.
-        // This ensures that encrypted messages are more likely to make sense to the
-        // SUT.
+        // This ensures that encrypted messages are more likely to make sense to the SUT.
         if (getTlsContext(context).getPreMasterSecret() == null) {
             makeNullCipherAsMostRecent(getTlsContext(context).getRecordLayer().getEncryptor(), getTlsContext(context));
             makeNullCipherAsMostRecent(getTlsContext(context).getRecordLayer().getDecryptor(), getTlsContext(context));

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ChangeCipherSpecInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ChangeCipherSpecInput.java
@@ -32,9 +32,11 @@ public class ChangeCipherSpecInput extends DtlsInput {
 
     @Override
     public void postSendDtlsUpdate(TlsExecutionContext context) {
-        // TLS-Attacker instantiates non-null ciphers even when the pre-master secret has not been yet negotiated.
+        // TLS-Attacker instantiates non-null ciphers even when the pre-master secret
+        // has not been yet negotiated.
         // Here, we replace the ciphers instantiated in such cases by null ciphers.
-        // This ensures that encrypted messages are more likely to make sense to the SUT.
+        // This ensures that encrypted messages are more likely to make sense to the
+        // SUT.
         if (getTlsContext(context).getPreMasterSecret() == null) {
             makeNullCipherAsMostRecent(getTlsContext(context).getRecordLayer().getEncryptor(), getTlsContext(context));
             makeNullCipherAsMostRecent(getTlsContext(context).getRecordLayer().getDecryptor(), getTlsContext(context));
@@ -43,7 +45,7 @@ public class ChangeCipherSpecInput extends DtlsInput {
 
     private void makeNullCipherAsMostRecent(RecordCryptoUnit cryptoUnit, TlsContext context) {
         RecordCipher cipher = cryptoUnit.getRecordMostRecentCipher();
-        if (! (cipher instanceof RecordNullCipher)) {
+        if (!(cipher instanceof RecordNullCipher)) {
             cryptoUnit.removeCiphers(1);
             CipherState cipherState = cipher.getState();
             cryptoUnit.addNewRecordCipher(new RecordNullCipher(context, cipherState));

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ChangeCipherSpecInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ChangeCipherSpecInput.java
@@ -1,6 +1,5 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.tlsattacker.core.layer.context.TlsContext;
 import de.rub.nds.tlsattacker.core.protocol.message.ChangeCipherSpecMessage;
 import de.rub.nds.tlsattacker.core.record.cipher.CipherState;
@@ -26,7 +25,7 @@ public class ChangeCipherSpecInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         ChangeCipherSpecMessage ccs = new ChangeCipherSpecMessage();
         return new TlsProtocolMessage(ccs);
     }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientHelloInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientHelloInput.java
@@ -84,8 +84,7 @@ public class ClientHelloInput extends DtlsInput {
         // to work also with 1-CH DTLS handshakes.
         // (in which case, the clienthello is digested)
         if (forceDigest && state.getTlsContext().getDigest().getRawBytes().length == 0) {
-            DtlsHandshakeMessageFragment fragment = state.getTlsContext().getDtlsFragmentLayer()
-                    .wrapInSingleFragment(state.getTlsContext().getContext(), message, true);
+            DtlsHandshakeMessageFragment fragment = state.getTlsContext().getDtlsFragmentLayer().wrapInSingleFragment(state.getTlsContext().getContext(), message, true);
             state.getTlsContext().getDigest().append(fragment.getCompleteResultingMessage().getValue());
         }
     }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientHelloInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientHelloInput.java
@@ -1,6 +1,5 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.modifiablevariable.bytearray.ByteArrayExplicitValueModification;
 import de.rub.nds.modifiablevariable.bytearray.ModifiableByteArray;
 import de.rub.nds.tlsattacker.core.constants.CipherSuite;
@@ -9,6 +8,7 @@ import de.rub.nds.tlsattacker.core.protocol.message.ClientHelloMessage;
 import de.rub.nds.tlsattacker.core.state.State;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Arrays;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 public class ClientHelloInput extends DtlsInput {
@@ -47,7 +47,7 @@ public class ClientHelloInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         getConfig(context).setDefaultClientSupportedCipherSuites(Arrays.asList(suite));
         if (suite.name().contains("EC")) {
             getConfig(context).setAddECPointFormatExtension(true);
@@ -79,7 +79,7 @@ public class ClientHelloInput extends DtlsInput {
         return TlsInputType.HANDSHAKE;
     }
 
-    public void postSendDtlsUpdate(State state, ExecutionContext context) {
+    public void postSendDtlsUpdate(State state, TlsExecutionContext context) {
         // the second conjunction is used in case TLS-Attacker is updated
         // to work also with 1-CH DTLS handshakes.
         // (in which case, the clienthello is digested)

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientHelloInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientHelloInput.java
@@ -84,7 +84,8 @@ public class ClientHelloInput extends DtlsInput {
         // to work also with 1-CH DTLS handshakes.
         // (in which case, the clienthello is digested)
         if (forceDigest && state.getTlsContext().getDigest().getRawBytes().length == 0) {
-            DtlsHandshakeMessageFragment fragment = state.getTlsContext().getDtlsFragmentLayer().wrapInSingleFragment(state.getTlsContext().getContext(), message, true);
+            DtlsHandshakeMessageFragment fragment = state.getTlsContext().getDtlsFragmentLayer()
+                    .wrapInSingleFragment(state.getTlsContext().getContext(), message, true);
             state.getTlsContext().getDigest().append(fragment.getCompleteResultingMessage().getValue());
         }
     }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientHelloRenegotiationInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientHelloRenegotiationInput.java
@@ -39,17 +39,18 @@ public class ClientHelloRenegotiationInput extends TlsInput {
     @Override
     public boolean isEnabled(TlsExecutionContext context) {
         switch (enabled) {
-            case OWN_EPOCH_CHANGE :
+            case OWN_EPOCH_CHANGE:
                 // send epoch is 1 or more
                 return getTlsContext(context).getWriteEpoch() > 0;
-            case SERVER_EPOCH_CHANGE :
+            case SERVER_EPOCH_CHANGE:
                 // receive epoch is 1 or more
                 return getTlsContext(context).getReadEpoch() > 0;
-            case ONCE :
+            case ONCE:
                 return getTlsExecutionContext(context)
                         .getTlsStepContextStream()
-                        .noneMatch(s -> this.equals(s.getInput()) && s.getIndex() != getTlsExecutionContext(context).getStepCount() - 1);
-            default :
+                        .noneMatch(s -> this.equals(s.getInput())
+                                && s.getIndex() != getTlsExecutionContext(context).getStepCount() - 1);
+            default:
                 return true;
         }
     }
@@ -68,7 +69,7 @@ public class ClientHelloRenegotiationInput extends TlsInput {
         if (!isShort) {
             ModifiableByteArray sbyte = new ModifiableByteArray();
             sbyte.setModification(new ByteArrayExplicitValueModification(
-                    new byte[]{}));
+                    new byte[] {}));
             message.setSessionId(sbyte);
         }
 
@@ -76,7 +77,7 @@ public class ClientHelloRenegotiationInput extends TlsInput {
         if (!withCookie && getTlsContext(context).getDtlsCookie() != null) {
             ModifiableByteArray sbyte = new ModifiableByteArray();
             sbyte.setModification(new ByteArrayExplicitValueModification(
-                    new byte[]{}));
+                    new byte[] {}));
             message.setCookie(sbyte);
         }
 
@@ -87,12 +88,12 @@ public class ClientHelloRenegotiationInput extends TlsInput {
     public void postReceiveUpdate(TlsOutput output, OutputChecker<TlsOutput> abstractOutputChecker,
             TlsExecutionContext context) {
         switch (enabled) {
-            case ON_SERVER_HELLO :
+            case ON_SERVER_HELLO:
                 if (!TlsOutputChecker.hasServerHello(output)) {
                     getTlsExecutionContext(context).disableExecution();
                 }
                 break;
-            default :
+            default:
                 break;
         }
         super.postReceiveUpdate(output, abstractOutputChecker, context);

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientHelloRenegotiationInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientHelloRenegotiationInput.java
@@ -1,14 +1,14 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutputChecker;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputChecker;
 import de.rub.nds.modifiablevariable.bytearray.ByteArrayExplicitValueModification;
 import de.rub.nds.modifiablevariable.bytearray.ModifiableByteArray;
 import de.rub.nds.tlsattacker.core.constants.CipherSuite;
 import de.rub.nds.tlsattacker.core.protocol.message.ClientHelloMessage;
 import jakarta.xml.bind.annotation.XmlAttribute;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutputChecker;
 
 public class ClientHelloRenegotiationInput extends TlsInput {
@@ -37,7 +37,7 @@ public class ClientHelloRenegotiationInput extends TlsInput {
     }
 
     @Override
-    public boolean isEnabled(ExecutionContext context) {
+    public boolean isEnabled(TlsExecutionContext context) {
         switch (enabled) {
             case OWN_EPOCH_CHANGE :
                 // send epoch is 1 or more
@@ -55,7 +55,7 @@ public class ClientHelloRenegotiationInput extends TlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         getTlsContext(context).getDigest().reset();
         if (resetMSeq) {
             getTlsContext(context).setWriteSequenceNumber(getTlsContext(context).getWriteEpoch(), 0);
@@ -84,8 +84,8 @@ public class ClientHelloRenegotiationInput extends TlsInput {
     }
 
     @Override
-    public void postReceiveUpdate(AbstractOutput output, AbstractOutputChecker abstractOutputChecker,
-            ExecutionContext context) {
+    public void postReceiveUpdate(TlsOutput output, OutputChecker<TlsOutput> abstractOutputChecker,
+            TlsExecutionContext context) {
         switch (enabled) {
             case ON_SERVER_HELLO :
                 if (!TlsOutputChecker.hasServerHello(output)) {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientHelloWithSessionIdInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientHelloWithSessionIdInput.java
@@ -1,11 +1,11 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.tlsattacker.core.constants.CipherSuite;
 import de.rub.nds.tlsattacker.core.protocol.message.ClientHelloMessage;
 import de.rub.nds.tlsattacker.core.state.State;
 import de.rub.nds.tlsattacker.core.workflow.action.ResetConnectionAction;
 import jakarta.xml.bind.annotation.XmlAttribute;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 public class ClientHelloWithSessionIdInput extends DtlsInput {
@@ -40,7 +40,7 @@ public class ClientHelloWithSessionIdInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         // reset and resume the connection
         resetTransportHandler(getState(context));
         if (suite != null) {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientKeyExchangeInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientKeyExchangeInput.java
@@ -38,28 +38,28 @@ public class ClientKeyExchangeInput extends DtlsInput {
             throw new RuntimeException("Algorithm not set");
         }
         switch (algorithm) {
-            case RSA :
+            case RSA:
                 message = new RSAClientKeyExchangeMessage();
                 break;
-            case PSK :
+            case PSK:
                 message = new PskClientKeyExchangeMessage();
                 break;
-            case DH :
+            case DH:
                 message = new DHClientKeyExchangeMessage();
                 break;
-            case ECDH :
+            case ECDH:
                 message = new ECDHClientKeyExchangeMessage();
                 break;
-            case PSK_RSA :
+            case PSK_RSA:
                 message = new PskRsaClientKeyExchangeMessage();
                 break;
-            case GOST :
+            case GOST:
                 message = new GOSTClientKeyExchangeMessage();
                 break;
-            case SRP :
+            case SRP:
                 message = new SrpClientKeyExchangeMessage();
                 break;
-            default :
+            default:
                 throw new RuntimeException("Algorithm " + algorithm
                         + " not supported");
 

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientKeyExchangeInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ClientKeyExchangeInput.java
@@ -1,6 +1,5 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.tlsattacker.core.protocol.ProtocolMessage;
 import de.rub.nds.tlsattacker.core.protocol.message.DHClientKeyExchangeMessage;
 import de.rub.nds.tlsattacker.core.protocol.message.ECDHClientKeyExchangeMessage;
@@ -10,6 +9,7 @@ import de.rub.nds.tlsattacker.core.protocol.message.PskRsaClientKeyExchangeMessa
 import de.rub.nds.tlsattacker.core.protocol.message.RSAClientKeyExchangeMessage;
 import de.rub.nds.tlsattacker.core.protocol.message.SrpClientKeyExchangeMessage;
 import jakarta.xml.bind.annotation.XmlAttribute;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 /**
@@ -31,7 +31,7 @@ public class ClientKeyExchangeInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         getTlsContext(context).setPreMasterSecret(null);
         ProtocolMessage message = null;
         if (algorithm == null) {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/DtlsInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/DtlsInput.java
@@ -31,7 +31,7 @@ public abstract class DtlsInput extends TlsInput {
     }
 
     @Override
-    public final void preSendUpdate(com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext context) {
+    public final void preSendUpdate(TlsExecutionContext context) {
         TlsState state = getTlsExecutionContext(context).getState();
 
         // if different epoch than current, set the epoch in TLS context
@@ -52,7 +52,7 @@ public abstract class DtlsInput extends TlsInput {
     }
 
     @Override
-    public final void postSendUpdate(com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext context) {
+    public final void postSendUpdate(TlsExecutionContext context) {
         // reset epoch number and, if original epoch > 0, reactivate encryption
         if (contextEpoch != null) {
             getTlsExecutionContext(context).getState().getTlsContext().setWriteEpoch(contextEpoch);

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/DtlsInputWrapper.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/DtlsInputWrapper.java
@@ -5,7 +5,7 @@ import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
 
-public class DtlsInputWrapper extends DtlsInput{
+public class DtlsInputWrapper extends DtlsInput {
     private DtlsInput input;
 
     public DtlsInputWrapper(DtlsInput input) {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/DtlsInputWrapper.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/DtlsInputWrapper.java
@@ -1,10 +1,9 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutputChecker;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputChecker;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
 
 public class DtlsInputWrapper extends DtlsInput{
     private DtlsInput input;
@@ -43,7 +42,7 @@ public class DtlsInputWrapper extends DtlsInput{
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         return input.generateProtocolMessage(context);
     }
 
@@ -58,8 +57,8 @@ public class DtlsInputWrapper extends DtlsInput{
     }
 
     @Override
-    public void postReceiveUpdate(AbstractOutput output, AbstractOutputChecker abstractOutputChecker,
-            ExecutionContext context) {
+    public void postReceiveUpdate(TlsOutput output, OutputChecker<TlsOutput> abstractOutputChecker,
+            TlsExecutionContext context) {
         input.postReceiveUpdate(output, abstractOutputChecker, context);
     }
 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/FinishedInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/FinishedInput.java
@@ -25,8 +25,10 @@ public class FinishedInput extends DtlsInput {
         // System.out.println(ArrayConverter.bytesToHexString(state.getTlsContext().getDigest().getRawBytes()));
         FinishedMessage message = new FinishedMessage();
         lastSequenceNumber = getTlsContext(context).getWriteSequenceNumber(getTlsContext(context).getWriteEpoch());
-//        getTlsContext(context).setWriteEpoch(getTlsContext(context).getWriteEpoch() + 1);
-//        getTlsContext(context).setWriteSequenceNumber(getTlsContext(context).getWriteEpoch(), 0L);
+        // getTlsContext(context).setWriteEpoch(getTlsContext(context).getWriteEpoch() +
+        // 1);
+        // getTlsContext(context).setWriteSequenceNumber(getTlsContext(context).getWriteEpoch(),
+        // 0L);
         return new TlsProtocolMessage(message);
     }
 

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/FinishedInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/FinishedInput.java
@@ -25,10 +25,8 @@ public class FinishedInput extends DtlsInput {
         // System.out.println(ArrayConverter.bytesToHexString(state.getTlsContext().getDigest().getRawBytes()));
         FinishedMessage message = new FinishedMessage();
         lastSequenceNumber = getTlsContext(context).getWriteSequenceNumber(getTlsContext(context).getWriteEpoch());
-        // getTlsContext(context).setWriteEpoch(getTlsContext(context).getWriteEpoch() +
-        // 1);
-        // getTlsContext(context).setWriteSequenceNumber(getTlsContext(context).getWriteEpoch(),
-        // 0L);
+        // getTlsContext(context).setWriteEpoch(getTlsContext(context).getWriteEpoch() + 1);
+        // getTlsContext(context).setWriteSequenceNumber(getTlsContext(context).getWriteEpoch(), 0L);
         return new TlsProtocolMessage(message);
     }
 

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/FinishedInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/FinishedInput.java
@@ -1,12 +1,11 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutputChecker;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputChecker;
 import de.rub.nds.tlsattacker.core.protocol.message.FinishedMessage;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutputChecker;
 
 public class FinishedInput extends DtlsInput {
@@ -21,7 +20,7 @@ public class FinishedInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         // Uncomment line to print digest, TODO remove this when polishing things up
         // System.out.println(ArrayConverter.bytesToHexString(state.getTlsContext().getDigest().getRawBytes()));
         FinishedMessage message = new FinishedMessage();
@@ -39,8 +38,8 @@ public class FinishedInput extends DtlsInput {
     }
 
     @Override
-    public void postReceiveUpdate(AbstractOutput output, AbstractOutputChecker abstractOutputChecker,
-            ExecutionContext context) {
+    public void postReceiveUpdate(TlsOutput output, OutputChecker<TlsOutput> abstractOutputChecker,
+            TlsExecutionContext context) {
         if (resetMSeq) {
             if (TlsOutputChecker.hasChangeCipherSpec(output)) {
                 getTlsContext(context).setWriteSequenceNumber(getTlsContext(context).getWriteEpoch(), 0);

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/GenericTlsInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/GenericTlsInput.java
@@ -104,7 +104,7 @@ public class GenericTlsInput extends DtlsInput {
             @XmlElement(type = SrpServerKeyExchangeMessage.class, name = "SrpServerKeyExchange"),
             @XmlElement(type = SrpClientKeyExchangeMessage.class, name = "SrpClientKeyExchange"),
             @XmlElement(type = EndOfEarlyDataMessage.class, name = "EndOfEarlyData"),
-            @XmlElement(type = EncryptedExtensionsMessage.class, name = "EncryptedExtensions")})
+            @XmlElement(type = EncryptedExtensionsMessage.class, name = "EncryptedExtensions") })
     private ProtocolMessage message;
 
     public GenericTlsInput() {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/GenericTlsInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/GenericTlsInput.java
@@ -104,7 +104,7 @@ public class GenericTlsInput extends DtlsInput {
             @XmlElement(type = SrpServerKeyExchangeMessage.class, name = "SrpServerKeyExchange"),
             @XmlElement(type = SrpClientKeyExchangeMessage.class, name = "SrpClientKeyExchange"),
             @XmlElement(type = EndOfEarlyDataMessage.class, name = "EndOfEarlyData"),
-            @XmlElement(type = EncryptedExtensionsMessage.class, name = "EncryptedExtensions") })
+            @XmlElement(type = EncryptedExtensionsMessage.class, name = "EncryptedExtensions")})
     private ProtocolMessage message;
 
     public GenericTlsInput() {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/GenericTlsInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/GenericTlsInput.java
@@ -1,6 +1,5 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.modifiablevariable.ModifiableVariable;
 import de.rub.nds.modifiablevariable.ModifiableVariableHolder;
 import de.rub.nds.tlsattacker.core.http.HttpRequestMessage;
@@ -52,6 +51,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
 
@@ -122,7 +122,7 @@ public class GenericTlsInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         stripFields(message);
         return new TlsProtocolMessage(message);
     }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/HelloRequestInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/HelloRequestInput.java
@@ -1,13 +1,11 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutputChecker;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.tlsattacker.core.protocol.message.HelloRequestMessage;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Arrays;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutputChecker;
 
 public class HelloRequestInput extends DtlsInput {
@@ -29,7 +27,7 @@ public class HelloRequestInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         if (resetSequenceNumber) {
             origMsgSeqNum = getTlsContext(context).getDtlsFragmentLayer().getWriteHandshakeMessageSequence();
             getTlsContext(context).getDtlsFragmentLayer().setWriteHandshakeMessageSequence(0);
@@ -47,9 +45,9 @@ public class HelloRequestInput extends DtlsInput {
     }
 
     @Override
-    public void postReceiveUpdate(AbstractOutput output, AbstractOutputChecker abstractOutputChecker,
-            ExecutionContext context) {
-        if (! TlsOutputChecker.hasClientHello(output)) {
+    public void postReceiveUpdate(TlsOutput output, TlsOutputChecker abstractOutputChecker,
+            TlsExecutionContext context) {
+        if (!TlsOutputChecker.hasClientHello(output)) {
             if (disableOnRefusal) {
                 context.disableExecution();
             } else if (resetSequenceNumber) {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/HelloRequestInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/HelloRequestInput.java
@@ -1,5 +1,6 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputChecker;
 import de.rub.nds.tlsattacker.core.protocol.message.HelloRequestMessage;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import java.util.Arrays;
@@ -45,7 +46,7 @@ public class HelloRequestInput extends DtlsInput {
     }
 
     @Override
-    public void postReceiveUpdate(TlsOutput output, TlsOutputChecker abstractOutputChecker,
+    public void postReceiveUpdate(TlsOutput output, OutputChecker<TlsOutput> abstractOutputChecker,
             TlsExecutionContext context) {
         if (!TlsOutputChecker.hasClientHello(output)) {
             if (disableOnRefusal) {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/HelloVerifyRequestInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/HelloVerifyRequestInput.java
@@ -1,9 +1,9 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.tlsattacker.core.protocol.message.HelloVerifyRequestMessage;
 import de.rub.nds.tlsattacker.core.state.State;
 import jakarta.xml.bind.annotation.XmlAttribute;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 public class HelloVerifyRequestInput extends DtlsInput {
@@ -19,7 +19,7 @@ public class HelloVerifyRequestInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         HelloVerifyRequestMessage hvr = new HelloVerifyRequestMessage();
         return new TlsProtocolMessage(hvr);
     }
@@ -29,7 +29,7 @@ public class HelloVerifyRequestInput extends DtlsInput {
         return TlsInputType.HANDSHAKE;
     }
 
-    public void postSendDtlsUpdate(State state, ExecutionContext context) {
+    public void postSendDtlsUpdate(State state, TlsExecutionContext context) {
         if (resetDigest) {
             state.getTlsContext().getDigest().reset();
         }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerHelloDoneInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerHelloDoneInput.java
@@ -1,7 +1,7 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.tlsattacker.core.protocol.message.ServerHelloDoneMessage;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 public class ServerHelloDoneInput extends DtlsInput {
@@ -11,7 +11,7 @@ public class ServerHelloDoneInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         ServerHelloDoneMessage shd = new ServerHelloDoneMessage();
         return new TlsProtocolMessage(shd);
     }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerHelloInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerHelloInput.java
@@ -74,7 +74,7 @@ public class ServerHelloInput extends DtlsInput {
             Pair<ProtocolMessage, Record> lastChPair = null;
             int lastChStepIndex = -1;
             List<Pair<ProtocolMessage, Record>> msgRecPairs = ctx.getReceivedMessagesAndRecords();
-            for (int i=0; i<msgRecPairs.size(); i++) {
+            for (int i = 0; i < msgRecPairs.size(); i++) {
                 if (msgRecPairs.get(i).getKey() instanceof ClientHelloMessage) {
                     lastChStepIndex = i;
                     lastChPair = msgRecPairs.get(i);
@@ -83,15 +83,17 @@ public class ServerHelloInput extends DtlsInput {
 
             assert lastChPair != null;
 
-            // we reset the digest and append to it, in reverse order SH, the last CH before the SH and optionally the HR which prompted the CH (if such a HR was sent)
+            // we reset the digest and append to it, in reverse order SH, the last CH before
+            // the SH and optionally the HR which prompted the CH (if such a HR was sent)
             getTlsContext(ctx).getDigest().reset();
 
             if (digestHR && ctx.getStepContext(lastChStepIndex).getInput() instanceof HelloRequestInput) {
-                byte [] hrBytes = ctx.getStepContext(lastChStepIndex).getReceivedRecords().get(0).getCleanProtocolMessageBytes().getValue();
+                byte[] hrBytes = ctx.getStepContext(lastChStepIndex).getReceivedRecords().get(0)
+                        .getCleanProtocolMessageBytes().getValue();
                 getTlsContext(context).getDigest().append(hrBytes);
             }
-            byte [] chBytes = lastChPair.getRight().getCleanProtocolMessageBytes().getValue();
-            byte [] shBytes = ctx.getStepContext().getSentRecords().get(0).getCleanProtocolMessageBytes().getValue();
+            byte[] chBytes = lastChPair.getRight().getCleanProtocolMessageBytes().getValue();
+            byte[] shBytes = ctx.getStepContext().getSentRecords().get(0).getCleanProtocolMessageBytes().getValue();
             getTlsContext(context).getDigest().append(chBytes);
             getTlsContext(context).getDigest().append(shBytes);
         }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerHelloInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerHelloInput.java
@@ -1,8 +1,5 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutputChecker;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.tlsattacker.core.config.Config;
 import de.rub.nds.tlsattacker.core.constants.CipherSuite;
 import de.rub.nds.tlsattacker.core.protocol.ProtocolMessage;
@@ -15,6 +12,8 @@ import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutputChecker;
 
 public class ServerHelloInput extends DtlsInput {
 
@@ -37,7 +36,7 @@ public class ServerHelloInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         Config config = getConfig(context);
 
         config.setDefaultServerSupportedCipherSuites(Arrays.asList(suite));
@@ -68,8 +67,8 @@ public class ServerHelloInput extends DtlsInput {
     }
 
     @Override
-    public void postReceiveUpdate(AbstractOutput output, AbstractOutputChecker abstractOutputChecker,
-            ExecutionContext context) {
+    public void postReceiveUpdate(TlsOutput output, TlsOutputChecker abstractOutputChecker,
+            TlsExecutionContext context) {
         TlsExecutionContext ctx = getTlsExecutionContext(context);
         if (shortHs && context.isExecutionEnabled()) {
             Pair<ProtocolMessage, Record> lastChPair = null;

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerHelloInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerHelloInput.java
@@ -1,5 +1,6 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputChecker;
 import de.rub.nds.tlsattacker.core.config.Config;
 import de.rub.nds.tlsattacker.core.constants.CipherSuite;
 import de.rub.nds.tlsattacker.core.protocol.ProtocolMessage;
@@ -13,7 +14,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
-import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutputChecker;
 
 public class ServerHelloInput extends DtlsInput {
 
@@ -67,7 +67,7 @@ public class ServerHelloInput extends DtlsInput {
     }
 
     @Override
-    public void postReceiveUpdate(TlsOutput output, TlsOutputChecker abstractOutputChecker,
+    public void postReceiveUpdate(TlsOutput output, OutputChecker<TlsOutput> abstractOutputChecker,
             TlsExecutionContext context) {
         TlsExecutionContext ctx = getTlsExecutionContext(context);
         if (shortHs && context.isExecutionEnabled()) {

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerHelloInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerHelloInput.java
@@ -83,13 +83,12 @@ public class ServerHelloInput extends DtlsInput {
 
             assert lastChPair != null;
 
-            // we reset the digest and append to it, in reverse order SH, the last CH before
-            // the SH and optionally the HR which prompted the CH (if such a HR was sent)
+            // We reset the digest and append to it, in reverse order SH, the last CH before
+            // the SH and optionally the HR which prompted the CH (if such a HR was sent).
             getTlsContext(ctx).getDigest().reset();
 
             if (digestHR && ctx.getStepContext(lastChStepIndex).getInput() instanceof HelloRequestInput) {
-                byte[] hrBytes = ctx.getStepContext(lastChStepIndex).getReceivedRecords().get(0)
-                        .getCleanProtocolMessageBytes().getValue();
+                byte[] hrBytes = ctx.getStepContext(lastChStepIndex).getReceivedRecords().get(0).getCleanProtocolMessageBytes().getValue();
                 getTlsContext(context).getDigest().append(hrBytes);
             }
             byte[] chBytes = lastChPair.getRight().getCleanProtocolMessageBytes().getValue();

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerKeyExchangeInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerKeyExchangeInput.java
@@ -1,11 +1,11 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import de.rub.nds.tlsattacker.core.protocol.ProtocolMessage;
 import de.rub.nds.tlsattacker.core.protocol.message.DHEServerKeyExchangeMessage;
 import de.rub.nds.tlsattacker.core.protocol.message.ECDHEServerKeyExchangeMessage;
 import de.rub.nds.tlsattacker.core.protocol.message.PskServerKeyExchangeMessage;
 import jakarta.xml.bind.annotation.XmlAttribute;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 /**
@@ -26,7 +26,7 @@ public class ServerKeyExchangeInput extends DtlsInput {
     }
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         if (algorithm == null) {
             throw new RuntimeException("Algorithm not set");
         }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerKeyExchangeInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerKeyExchangeInput.java
@@ -32,16 +32,16 @@ public class ServerKeyExchangeInput extends DtlsInput {
         }
         ProtocolMessage ske = null;
         switch (algorithm) {
-            case DH :
+            case DH:
                 ske = new DHEServerKeyExchangeMessage();
                 break;
-            case ECDH :
+            case ECDH:
                 ske = new ECDHEServerKeyExchangeMessage();
                 break;
             case PSK:
                 ske = new PskServerKeyExchangeMessage();
                 break;
-            default :
+            default:
                 throw new RuntimeException("Algorithm " + algorithm
                         + " not supported");
         }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/TlsAlphabetPojoXml.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/TlsAlphabetPojoXml.java
@@ -1,7 +1,6 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabet.xml.AlphabetPojoXml;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractInput;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
@@ -14,7 +13,7 @@ import java.util.List;
  */
 @XmlRootElement(name = "alphabet")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class TlsAlphabetPojoXml extends AlphabetPojoXml {
+public class TlsAlphabetPojoXml extends AlphabetPojoXml<TlsInput> {
     @XmlElements(value = {
             @XmlElement(type = GenericTlsInput.class, name = "GenericTlsInput"),
             @XmlElement(type = ChangeCipherSpecInput.class, name = "ChangeCipherSpecInput"),
@@ -31,18 +30,18 @@ public class TlsAlphabetPojoXml extends AlphabetPojoXml {
             @XmlElement(type = ClientKeyExchangeInput.class, name = "ClientKeyExchangeInput"),
             @XmlElement(type = CertificateInput.class, name = "CertificateInput"),
             @XmlElement(type = ApplicationInput.class, name = "ApplicationInput"),
-            @XmlElement(type = HelloRequestInput.class, name = "HelloRequestInput")})
-    private List<AbstractInput> inputs;
+            @XmlElement(type = HelloRequestInput.class, name = "HelloRequestInput") })
+    private List<TlsInput> inputs;
 
     public TlsAlphabetPojoXml() {
     }
 
-    public TlsAlphabetPojoXml(List<AbstractInput> inputs) {
+    public TlsAlphabetPojoXml(List<TlsInput> inputs) {
         this.inputs = inputs;
     }
 
     @Override
-    public List<AbstractInput> getInputs() {
+    public List<TlsInput> getInputs() {
         return inputs;
     }
 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/TlsInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/TlsInput.java
@@ -60,6 +60,5 @@ public abstract class TlsInput extends AbstractInputXml<TlsOutput, TlsProtocolMe
         return getTlsExecutionContext(context).getState().getState().getConfig();
     }
 
-    // TODO: why did this have an override?
     public abstract TlsInputType getInputType();
 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/TlsInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/TlsInput.java
@@ -1,9 +1,7 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutputChecker;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.xml.AbstractInputXml;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractInputXml;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputChecker;
 import de.rub.nds.tlsattacker.core.config.Config;
 import de.rub.nds.tlsattacker.core.layer.context.TlsContext;
 import de.rub.nds.tlsattacker.core.state.State;
@@ -11,9 +9,10 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs.TlsOutput;
 
 @XmlAccessorType(XmlAccessType.FIELD)
-public abstract class TlsInput extends AbstractInputXml {
+public abstract class TlsInput extends AbstractInputXml<TlsOutput, TlsProtocolMessage, TlsExecutionContext> {
 
     public TlsInput() {
         super();
@@ -24,37 +23,43 @@ public abstract class TlsInput extends AbstractInputXml {
     }
 
     @Override
-    public void preSendUpdate(ExecutionContext context) {
+    public void preSendUpdate(TlsExecutionContext context) {
     }
 
     @Override
-    public abstract TlsProtocolMessage generateProtocolMessage(ExecutionContext context);
+    public abstract TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context);
 
     @Override
-    public void postSendUpdate(ExecutionContext context) {
+    public void postSendUpdate(TlsExecutionContext context) {
     }
 
     @Override
-    public void postReceiveUpdate(AbstractOutput output, AbstractOutputChecker abstractOutputChecker,
-            ExecutionContext context) {
+    // FIXME: To be able to override properly an OutputChecker<O> is expected,
+    // instead of something that implements outputChecker<O> It might be worth
+    // updating the mapperInput class to allow the use of own outputcheckers
+    // directly.
+    public void postReceiveUpdate(TlsOutput output, OutputChecker<TlsOutput> outputChecker,
+            TlsExecutionContext context) {
     }
 
-    protected final TlsExecutionContext getTlsExecutionContext(ExecutionContext context) {
-        return (TlsExecutionContext) context;
+    // TODO: Consider whether these should still be in the API now that casts are
+    // largely unneccesary.
+    protected final TlsExecutionContext getTlsExecutionContext(TlsExecutionContext context) {
+        return context;
     }
 
-    protected final TlsContext getTlsContext(ExecutionContext context) {
-        return ((TlsExecutionContext) context).getState().getTlsContext();
+    protected final TlsContext getTlsContext(TlsExecutionContext context) {
+        return context.getState().getTlsContext();
     }
 
-    protected final State getState(ExecutionContext context) {
+    protected final State getState(TlsExecutionContext context) {
         return getTlsExecutionContext(context).getState().getState();
     }
 
-    protected final Config getConfig(ExecutionContext context) {
+    protected final Config getConfig(TlsExecutionContext context) {
         return getTlsExecutionContext(context).getState().getState().getConfig();
     }
 
-    @Override
+    // TODO: why did this have an override?
     public abstract TlsInputType getInputType();
 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/TlsInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/TlsInput.java
@@ -43,7 +43,7 @@ public abstract class TlsInput extends AbstractInputXml<TlsOutput, TlsProtocolMe
     }
 
     // TODO: Consider whether these should still be in the API now that casts are
-    // largely unneccesary.
+    // largely unnecesisary.
     protected final TlsExecutionContext getTlsExecutionContext(TlsExecutionContext context) {
         return context;
     }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/WaitClientConnectInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/WaitClientConnectInput.java
@@ -1,13 +1,13 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import org.apache.commons.lang3.NotImplementedException;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsExecutionContext;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 public class WaitClientConnectInput extends TlsInput {
 
     @Override
-    public TlsProtocolMessage generateProtocolMessage(ExecutionContext context) {
+    public TlsProtocolMessage generateProtocolMessage(TlsExecutionContext context) {
         throw new NotImplementedException("Cannot generate message");
     }
 

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/outputs/TlsOutput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/outputs/TlsOutput.java
@@ -1,9 +1,9 @@
 package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput;
 import java.util.Collections;
 import java.util.List;
+import se.uu.it.dtlsfuzzer.components.sul.mapper.TlsProtocolMessage;
 
 /**
  * The outputs used in learning can be messages/records, application data, and
@@ -11,14 +11,24 @@ import java.util.List;
  *
  * We restrict ourselves only to the received message types.
  */
-public class TlsOutput extends AbstractOutput {
+public class TlsOutput extends AbstractOutput<TlsOutput, TlsProtocolMessage> {
 
     public TlsOutput(String name) {
         super(name);
         this.messages = Collections.emptyList();
     }
 
-    public TlsOutput(String name, List<ProtocolMessage> messages) {
+    public TlsOutput(String name, List<TlsProtocolMessage> messages) {
         super(name, Collections.emptyList());
+    }
+
+    @Override
+    public TlsOutput buildOutput(String name) {
+        return new TlsOutput(name);
+    }
+
+    @Override
+    protected TlsOutput convertOutput() {
+        return (TlsOutput) this;
     }
 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/outputs/TlsOutput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/outputs/TlsOutput.java
@@ -29,6 +29,6 @@ public class TlsOutput extends AbstractOutput<TlsOutput, TlsProtocolMessage> {
 
     @Override
     protected TlsOutput convertOutput() {
-        return (TlsOutput) this;
+        return this;
     }
 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/outputs/TlsOutputBuilder.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/outputs/TlsOutputBuilder.java
@@ -2,14 +2,14 @@ package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs;
 
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputBuilder;
 
-public class TlsOutputBuilder implements OutputBuilder<TlsOutput> {
+public class TlsOutputBuilder extends  OutputBuilder<TlsOutput> {
 
     public TlsOutputBuilder() {
         super();
     }
 
     @Override
-    public TlsOutput buildOutput(String name) {
+    public TlsOutput buildOutputExact(String name) {
         return new TlsOutput(name);
     }
 }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/outputs/TlsOutputBuilder.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/outputs/TlsOutputBuilder.java
@@ -1,0 +1,15 @@
+package se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.outputs;
+
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputBuilder;
+
+public class TlsOutputBuilder implements OutputBuilder<TlsOutput> {
+
+    public TlsOutputBuilder() {
+        super();
+    }
+
+    @Override
+    public TlsOutput buildOutput(String name) {
+        return new TlsOutput(name);
+    }
+}

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/outputs/TlsOutputChecker.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/outputs/TlsOutputChecker.java
@@ -7,7 +7,8 @@ import java.util.Optional;
 import se.uu.it.dtlsfuzzer.components.sul.mapper.symbols.inputs.KeyExchangeAlgorithm;
 
 /**
- * Provides an interface for analyzing outputs so that how the actual strings are formed is decoupled from the checking code.
+ * Provides an interface for analyzing outputs so that how the actual strings
+ * are formed is decoupled from the checking code.
  */
 public class TlsOutputChecker implements OutputChecker<TlsOutput> {
     private static String APPLICATION = "APPLICATION";
@@ -119,7 +120,7 @@ public class TlsOutputChecker implements OutputChecker<TlsOutput> {
     }
 
     public static X509PublicKeyType getClientCertificateType(TlsOutput output) {
-        assert(hasCertificate(output) && output.isAtomic());
+        assert (hasCertificate(output) && output.isAtomic());
         if (hasEmptyCertificate(output)) {
             return null;
         } else {
@@ -138,16 +139,16 @@ public class TlsOutputChecker implements OutputChecker<TlsOutput> {
     }
 
     public static X509PublicKeyType getCertificateType(TlsOutput output) {
-        Optional<X509PublicKeyType> opt = Arrays.stream(X509PublicKeyType.values()).filter(ctype -> output.getName().contains(ctype.name())).findFirst();
+        Optional<X509PublicKeyType> opt = Arrays.stream(X509PublicKeyType.values())
+                .filter(ctype -> output.getName().contains(ctype.name())).findFirst();
         return opt.orElseGet(() -> null);
     }
-
 
     public static KeyExchangeAlgorithm getKeyExchangeAlgorithm(TlsOutput output) {
         if (hasClientKeyExchange(output) || hasServerKeyExchange(output)) {
             String keyExchange = output.getName().split("_", -1)[0];
             if (keyExchange.endsWith("DHE")) {
-                keyExchange = keyExchange.substring(0, keyExchange.length()-1);
+                keyExchange = keyExchange.substring(0, keyExchange.length() - 1);
             }
             return KeyExchangeAlgorithm.valueOf(keyExchange);
         }


### PR DESCRIPTION
I'm currently having the issue that when i try to compile I get the following error. I've tried updating the POM with ralib even though it should not be needed but it didn't make any difference. 
`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.14.0:compile (default-compile) on project dtls-fuzzer: Fatal error compiling: Cannot load from object array because "this.hashes" is null`

@kostis If you could take a look that would be appreciated, as I've tried everything i could think of currently.