### PR TITLE
CI: Update Ubuntu version for PionDTLS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
 
   PionDTLS-2-0-9_Server_psk:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
-    runs-on: ubuntu-20.04 # due to needing an old version of golang
+    runs-on: ubuntu-24.04 # due to needing an old version of golang
     strategy:
       fail-fast: true
     steps:
@@ -295,7 +295,7 @@ jobs:
 
   PionDTLS-2-0-9_Client_psk:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
-    runs-on: ubuntu-20.04 # due to needing an old version of golang
+    runs-on: ubuntu-24.04 # due to needing an old version of golang
     strategy:
       fail-fast: true
     steps:


### PR DESCRIPTION
Ubuntu 20.04 is not supported by GitHub actions since 15 April 2025, so we update the actions for PionDTLS to use the most recent version of Ubuntu (24.04) instead.