### PR TITLE
Reduce startWait time in test configurations

### DIFF
--- a/args/jsse/learn_jsse_client_ecdhe_cert
+++ b/args/jsse/learn_jsse_client_ecdhe_cert
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-2000
+1000
 -responseWait
 200
 -protocol

--- a/args/jsse/learn_jsse_server_ecdhe_cert_req
+++ b/args/jsse/learn_jsse_server_ecdhe_cert_req
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-2000
+1000
 -responseWait
 200
 -protocol

--- a/args/jsse/learn_jsse_server_rsa_cert_none
+++ b/args/jsse/learn_jsse_server_rsa_cert_none
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-2000
+1000
 -responseWait
 200
 -protocol

--- a/args/jsse/learn_jsse_server_rsa_cert_nreq
+++ b/args/jsse/learn_jsse_server_rsa_cert_nreq
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-2000
+1000
 -responseWait
 200
 -protocol

--- a/args/jsse/learn_jsse_server_rsa_cert_req
+++ b/args/jsse/learn_jsse_server_rsa_cert_req
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-2000
+1000
 -responseWait
 200
 -protocol

--- a/args/scandium/learn_scandium_client_ecdhe_cert
+++ b/args/scandium/learn_scandium_client_ecdhe_cert
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-4000
+1000
 -responseWait
 100
 -protocol

--- a/args/scandium/learn_scandium_client_ecdhe_cert_excl
+++ b/args/scandium/learn_scandium_client_ecdhe_cert_excl
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-4000
+1000
 -responseWait
 100
 -protocol

--- a/args/scandium/learn_scandium_client_psk
+++ b/args/scandium/learn_scandium_client_psk
@@ -6,7 +6,7 @@ ${sul.port}
 -protocol
 DTLS12
 -startWait
-4000
+1000
 -responseWait
 100
 -cmd

--- a/args/scandium/learn_scandium_server_ecdhe_cert_req
+++ b/args/scandium/learn_scandium_server_ecdhe_cert_req
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-4000
+1000
 -responseWait
 100
 -protocol

--- a/args/scandium/learn_scandium_server_ecdhe_cert_req_excl
+++ b/args/scandium/learn_scandium_server_ecdhe_cert_req_excl
@@ -2,7 +2,7 @@
 -connect
 localhost:${sul.port}
 -startWait
-4000
+1000
 -responseWait
 100
 -protocol

--- a/args/scandium/learn_scandium_server_psk
+++ b/args/scandium/learn_scandium_server_psk
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-4000
+1000
 -responseWait
 100
 -protocol


### PR DESCRIPTION
Modification:
1. args/jsse/learn_jsse_client_ecdhe_cert
change `-startWait` from 2000 to 1000

2. args/jsse/learn_jsse_server_ecdhe_cert_req
change `-startWait` from 2000 to 1000

3. args/scandium/learn_scandium_server_ecdhe_cert_req
change `-startWait` from 4000 to 1000

Results:
GitHub CI Tests can finish much faster:

1. CI / JSSE-12-0-2_Server_ecdhe_cert_req (push)
From 22 minutes to 16 minutes

2. CI / JSSE-12-0-2_Client_ecdhe_cert (push)
From 35 minutes to 25 minutes

3. CI / Scandium-2-0-0-M16_Server_ecdhe_cert_req (push)
From 33 minutes to 17 minutes