### PR TITLE
Decrease Client test configurations' startWait time

### DIFF
--- a/args/ctinydtls/learn_ctinydtls_client_ecdhe_cert
+++ b/args/ctinydtls/learn_ctinydtls_client_ecdhe_cert
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-100
+0
 -responseWait
 100
 -sulConfig

--- a/args/ctinydtls/learn_ctinydtls_client_ecdhe_cert
+++ b/args/ctinydtls/learn_ctinydtls_client_ecdhe_cert
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-0
+50
 -responseWait
 100
 -sulConfig

--- a/args/ctinydtls/learn_ctinydtls_client_ecdhe_cert_shorths
+++ b/args/ctinydtls/learn_ctinydtls_client_ecdhe_cert_shorths
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-100
+0
 -alphabet
 ${alphabets.clients}/tinydtls_ecdhe8_cert.xml
 -responseWait

--- a/args/ctinydtls/learn_ctinydtls_client_ecdhe_cert_shorths
+++ b/args/ctinydtls/learn_ctinydtls_client_ecdhe_cert_shorths
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-0
+50
 -alphabet
 ${alphabets.clients}/tinydtls_ecdhe8_cert.xml
 -responseWait

--- a/args/ctinydtls/learn_ctinydtls_client_psk
+++ b/args/ctinydtls/learn_ctinydtls_client_psk
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-0
+50
 -alphabet
 ${alphabets.clients}/psk8.xml
 -responseWait

--- a/args/ctinydtls/learn_ctinydtls_client_psk_shorths
+++ b/args/ctinydtls/learn_ctinydtls_client_psk_shorths
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-0
+50
 -responseWait
 100
 -cmd

--- a/args/ctinydtls/learn_ctinydtls_server_ecdhe_cert_none
+++ b/args/ctinydtls/learn_ctinydtls_server_ecdhe_cert_none
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-100
+50
 -alphabet
 ${alphabets.servers}/ecdhe8_cert.xml
 -responseWait

--- a/args/ctinydtls/learn_ctinydtls_server_ecdhe_cert_req
+++ b/args/ctinydtls/learn_ctinydtls_server_ecdhe_cert_req
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-100
+50
 -responseWait
 100
 -cmd

--- a/args/ctinydtls/learn_ctinydtls_server_psk
+++ b/args/ctinydtls/learn_ctinydtls_server_psk
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-100
+50
 -alphabet
 ${alphabets.servers}/psk8.xml
 -responseWait

--- a/args/etinydtls/learn_etinydtls_client_ecdhe_cert
+++ b/args/etinydtls/learn_etinydtls_client_ecdhe_cert
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-100
+0
 -responseWait
 100
 -sulConfig

--- a/args/etinydtls/learn_etinydtls_client_ecdhe_cert
+++ b/args/etinydtls/learn_etinydtls_client_ecdhe_cert
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-0
+50
 -responseWait
 100
 -sulConfig

--- a/args/etinydtls/learn_etinydtls_client_psk
+++ b/args/etinydtls/learn_etinydtls_client_psk
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-0
+50
 -alphabet
 ${alphabets.clients}/tinydtls_psk8.xml
 -responseWait

--- a/args/etinydtls/learn_etinydtls_server_ecdhe_cert_none
+++ b/args/etinydtls/learn_etinydtls_server_ecdhe_cert_none
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-100
+50
 -alphabet
 ${alphabets.servers}/ecdhe8_cert.xml
 -responseWait

--- a/args/etinydtls/learn_etinydtls_server_ecdhe_cert_req
+++ b/args/etinydtls/learn_etinydtls_server_ecdhe_cert_req
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-100
+50
 -alphabet
 ${alphabets.servers}/ecdhe8_cert.xml
 -responseWait

--- a/args/etinydtls/learn_etinydtls_server_psk
+++ b/args/etinydtls/learn_etinydtls_server_psk
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-100
+50
 -alphabet
 ${alphabets.servers}/psk8.xml
 -responseWait

--- a/args/jsse/learn_jsse_client_ecdhe_cert
+++ b/args/jsse/learn_jsse_client_ecdhe_cert
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-0
+1000
 -responseWait
 200
 -protocol

--- a/args/jsse/learn_jsse_client_ecdhe_cert
+++ b/args/jsse/learn_jsse_client_ecdhe_cert
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-1000
+0
 -responseWait
 200
 -protocol

--- a/args/jsse/learn_jsse_client_ecdhe_cert
+++ b/args/jsse/learn_jsse_client_ecdhe_cert
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-1000
+500
 -responseWait
 200
 -protocol

--- a/args/scandium/learn_scandium_client_ecdhe_cert
+++ b/args/scandium/learn_scandium_client_ecdhe_cert
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-0
+1000
 -responseWait
 100
 -protocol

--- a/args/scandium/learn_scandium_client_ecdhe_cert
+++ b/args/scandium/learn_scandium_client_ecdhe_cert
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-1000
+0
 -responseWait
 100
 -protocol

--- a/args/scandium/learn_scandium_client_ecdhe_cert
+++ b/args/scandium/learn_scandium_client_ecdhe_cert
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-1000
+500
 -responseWait
 100
 -protocol

--- a/args/scandium/learn_scandium_client_ecdhe_cert_excl
+++ b/args/scandium/learn_scandium_client_ecdhe_cert_excl
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-0
+1000
 -responseWait
 100
 -protocol

--- a/args/scandium/learn_scandium_client_ecdhe_cert_excl
+++ b/args/scandium/learn_scandium_client_ecdhe_cert_excl
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-1000
+0
 -responseWait
 100
 -protocol

--- a/args/scandium/learn_scandium_client_ecdhe_cert_excl
+++ b/args/scandium/learn_scandium_client_ecdhe_cert_excl
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-1000
+500
 -responseWait
 100
 -protocol

--- a/args/scandium/learn_scandium_client_psk
+++ b/args/scandium/learn_scandium_client_psk
@@ -6,7 +6,7 @@ ${sul.port}
 -protocol
 DTLS12
 -startWait
-1000
+500
 -responseWait
 100
 -cmd

--- a/args/scandium/learn_scandium_client_psk
+++ b/args/scandium/learn_scandium_client_psk
@@ -6,7 +6,7 @@ ${sul.port}
 -protocol
 DTLS12
 -startWait
-1000
+0
 -responseWait
 100
 -cmd

--- a/args/scandium/learn_scandium_client_psk
+++ b/args/scandium/learn_scandium_client_psk
@@ -6,7 +6,7 @@ ${sul.port}
 -protocol
 DTLS12
 -startWait
-0
+1000
 -responseWait
 100
 -cmd

--- a/args/scandium/learn_scandium_client_psk
+++ b/args/scandium/learn_scandium_client_psk
@@ -3,12 +3,12 @@ state-fuzzer-client
 # SUT config
 -port
 ${sul.port}
--protocol
-DTLS12
 -startWait
 500
 -responseWait
 100
+-protocol
+DTLS12
 -cmd
 java -jar ${fuzzer.dir}/suts/scandium-${scandium.version}-dtls-clientserver.jar -client -port ${sul.port} -timeout 20000000 -trustLocation ${keystore}/ec_secp256r1.jks -trustPassword password -trustAlias dtls-fuzzer -keyLocation ${keystore}/ec_secp256r1.jks -keyPassword password -keyAlias dtls-fuzzer -cipherSuites TLS_PSK_WITH_AES_128_CCM_8,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256  -clientAuth NEEDED -starterAddress localhost:${fuzzer.port}
 -sulConfig

--- a/args/scandium/learn_scandium_server_ecdhe_cert_req
+++ b/args/scandium/learn_scandium_server_ecdhe_cert_req
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-1000
+500
 -responseWait
 100
 -protocol

--- a/args/scandium/learn_scandium_server_ecdhe_cert_req_excl
+++ b/args/scandium/learn_scandium_server_ecdhe_cert_req_excl
@@ -1,8 +1,10 @@
+state-fuzzer-server
+
 # SUT config
 -connect
 localhost:${sul.port}
 -startWait
-1000
+500
 -responseWait
 100
 -protocol

--- a/args/scandium/learn_scandium_server_psk
+++ b/args/scandium/learn_scandium_server_psk
@@ -4,7 +4,7 @@ state-fuzzer-server
 -connect
 localhost:${sul.port}
 -startWait
-1000
+500
 -responseWait
 100
 -protocol

--- a/args/wolfssl/learn_wolfssl_client_dhe_cert_nreq_DTLS13
+++ b/args/wolfssl/learn_wolfssl_client_dhe_cert_nreq_DTLS13
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-200
+0
 -responseWait
 200
 -protocol

--- a/args/wolfssl/learn_wolfssl_client_dhe_cert_req_DTLS13
+++ b/args/wolfssl/learn_wolfssl_client_dhe_cert_req_DTLS13
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-200
+0
 -responseWait
 200
 -protocol

--- a/args/wolfssl/learn_wolfssl_client_psk
+++ b/args/wolfssl/learn_wolfssl_client_psk
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-200
+0
 -responseWait
 200
 -protocol

--- a/args/wolfssl/learn_wolfssl_client_psk_DTLS13
+++ b/args/wolfssl/learn_wolfssl_client_psk_DTLS13
@@ -4,7 +4,7 @@ state-fuzzer-client
 -port
 ${sul.port}
 -startWait
-200
+0
 -responseWait
 200
 -protocol


### PR DESCRIPTION
## Main Changes
Reduce startWait from 1000 to 500 for JSSE client and Scandium client

**Result**
1. CI / JSSE-12-0-2_Client_ecdhe_cert (push) 
From `22m 16s` to `16m 47s`
2. CI / Scandium-2-0-0-M16_Client_ecdhe_cert (push) 
From `1m 47s` to `1m 11s`

## Other Changes
I reduced other client learning configurations' startWait to 0, which reduced some CI tests learning time by 1 or 2 minutes.
