### PR TITLE
Fix DTLS 1.2 OpenSSL 1.1.1k client fuzzing null exception

### DIFF
--- a/experiments/patches/TLS-Attacker-v6.3.4.patch
+++ b/experiments/patches/TLS-Attacker-v6.3.4.patch
@@ -271,7 +271,7 @@ index 7a74620ce..b6c9112f9 100644
                  return new LayerStack(
                          context,
 diff --git a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/context/TlsContext.java b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/context/TlsContext.java
-index 135a9e80f..7f1c89625 100644
+index 135a9e80f..20a636880 100644
 --- a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/context/TlsContext.java
 +++ b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/context/TlsContext.java
 @@ -80,6 +80,15 @@ import java.util.Set;
@@ -298,7 +298,7 @@ index 135a9e80f..7f1c89625 100644
  
      private Random random;
  
-@@ -2278,4 +2288,20 @@ public class TlsContext extends LayerContext {
+@@ -2278,4 +2288,21 @@ public class TlsContext extends LayerContext {
      public void setPeerReceiveLimit(Integer peerReceiveLimit) {
          this.peerReceiveLimit = peerReceiveLimit;
      }
@@ -315,7 +315,8 @@ index 135a9e80f..7f1c89625 100644
 +        return lastClientHelloCleanProtocolMessageBytes;
 +    }
 +
-+    public void setLastClientHelloCleanProtocolMessageBytes(byte[] lastClientHelloCleanProtocolMessageBytes) {
++    public void setLastClientHelloCleanProtocolMessageBytes(
++            byte[] lastClientHelloCleanProtocolMessageBytes) {
 +        this.lastClientHelloCleanProtocolMessageBytes = lastClientHelloCleanProtocolMessageBytes;
 +    }
  }

--- a/experiments/patches/TLS-Attacker-v6.3.4.patch
+++ b/experiments/patches/TLS-Attacker-v6.3.4.patch
@@ -271,7 +271,7 @@ index 7a74620ce..b6c9112f9 100644
                  return new LayerStack(
                          context,
 diff --git a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/context/TlsContext.java b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/context/TlsContext.java
-index 135a9e80f..09c55c01e 100644
+index 135a9e80f..7f1c89625 100644
 --- a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/context/TlsContext.java
 +++ b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/context/TlsContext.java
 @@ -80,6 +80,15 @@ import java.util.Set;
@@ -290,7 +290,15 @@ index 135a9e80f..09c55c01e 100644
      private List<Session> sessionList;
  
      private Keylogfile keylogfile;
-@@ -2278,4 +2287,12 @@ public class TlsContext extends LayerContext {
+@@ -412,6 +421,7 @@ public class TlsContext extends LayerContext {
+     private byte[] lastServerVerifyData;
+ 
+     private byte[] lastClientHello;
++    private byte[] lastClientHelloCleanProtocolMessageBytes;
+ 
+     private Random random;
+ 
+@@ -2278,4 +2288,20 @@ public class TlsContext extends LayerContext {
      public void setPeerReceiveLimit(Integer peerReceiveLimit) {
          this.peerReceiveLimit = peerReceiveLimit;
      }
@@ -302,9 +310,17 @@ index 135a9e80f..09c55c01e 100644
 +    public void setDtls13ShouldSendFinished(boolean dtls13ShouldSendFinished) {
 +        this.dtls13ShouldSendFinished = dtls13ShouldSendFinished;
 +    }
++
++    public byte[] getLastClientHelloCleanProtocolMessageBytes() {
++        return lastClientHelloCleanProtocolMessageBytes;
++    }
++
++    public void setLastClientHelloCleanProtocolMessageBytes(byte[] lastClientHelloCleanProtocolMessageBytes) {
++        this.lastClientHelloCleanProtocolMessageBytes = lastClientHelloCleanProtocolMessageBytes;
++    }
  }
 diff --git a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/impl/DtlsFragmentLayer.java b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/impl/DtlsFragmentLayer.java
-index 19802504f..b5315904c 100644
+index 19802504f..6f513d94d 100644
 --- a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/impl/DtlsFragmentLayer.java
 +++ b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/impl/DtlsFragmentLayer.java
 @@ -197,6 +197,12 @@ public class DtlsFragmentLayer
@@ -320,6 +336,19 @@ index 19802504f..b5315904c 100644
                      DtlsHandshakeMessageFragment fragment = new DtlsHandshakeMessageFragment();
                      fragment.setEpoch(tempHint.getEpoch());
                      DtlsHandshakeMessageFragmentParser parser =
+@@ -207,6 +213,12 @@ public class DtlsFragmentLayer
+                     parser.parse(fragment);
+                     fragment.setCompleteResultingMessage(
+                             fragment.getSerializer(context).serialize());
++                    if (fragment.getType().getValue()
++                            == HandshakeMessageType.CLIENT_HELLO.getValue()) {
++                        context.getTlsContext()
++                                .setLastClientHelloCleanProtocolMessageBytes(
++                                        fragment.getCompleteResultingMessage().getValue());
++                    }
+                     fragmentManager.addMessageFragment(fragment);
+                     List<DtlsHandshakeMessageFragment> uninterpretedMessageFragments =
+                             fragmentManager.getOrderedCombinedUninterpretedMessageFragments(
 diff --git a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/impl/FirstCachedUdpLayer.java b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/impl/FirstCachedUdpLayer.java
 new file mode 100644
 index 000000000..f2a7ff48e

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSul.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSul.java
@@ -209,7 +209,7 @@ public class TlsSul implements AbstractSul<TlsInput, TlsOutput, TlsExecutionCont
                 if (!firstClientHello.getName().equals("CLIENT_HELLO")) {
                     LOGGER.fatal("The first Client Hello should have been received");
                 }
-                context.addStepContext();
+//                context.addStepContext();
             }
         } catch (IOException e) {
             LOGGER.error("Could not initialize transport handler");

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerHelloInput.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/mapper/symbols/inputs/ServerHelloInput.java
@@ -108,7 +108,10 @@ public class ServerHelloInput extends DtlsInput {
                 byte[] hrBytes = context.getStepContext(lastChStepIndex).getReceivedRecords().get(0).getCleanProtocolMessageBytes().getValue();
                 context.getTlsContext().getDigest().append(hrBytes);
             }
-            byte[] chBytes = lastChPair.getRight().getCleanProtocolMessageBytes().getValue();
+            byte[] chBytes = context.getTlsContext().getLastClientHelloCleanProtocolMessageBytes();
+            if(chBytes.length==0){
+                System.out.println("No ClientHello clean protocol message found");
+            }
             byte[] shBytes = context.getStepContext().getSentRecords().get(0).getCleanProtocolMessageBytes().getValue();
             context.getTlsContext().getDigest().append(chBytes);
             context.getTlsContext().getDigest().append(shBytes);


### PR DESCRIPTION
[openssl 1.1.1k client learn logs.txt](https://github.com/user-attachments/files/20512577/openssl.1.1.1k.client.learn.logs.txt)

I ran the learning for about 4 hours, generated 39 hypotheses, and it was terminated by `NonDeterminismException`

I will remove `context.addStepContext()` and run learning again, tomorrow I will update what happend.
