### PR TITLE
Eliminate two warnings in use of String.split

### DIFF
--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSul.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/TlsSul.java
@@ -148,7 +148,7 @@ public class TlsSul implements AbstractSul<TlsInput, TlsOutput, TlsExecutionCont
             config.getDefaultServerConnection().setPort(port);
         } else {
             String realHost = ((TlsSulServerConfig) sulConfig).getHost();
-            var split = realHost.split(":");
+            var split = realHost.split(":", -1);
             int port = Integer.parseInt(split[1]);
             config.getDefaultClientConnection().setPort(port);
         }

--- a/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/config/TlsSulServerConfig.java
+++ b/src/main/java/se/uu/it/dtlsfuzzer/components/sul/core/config/TlsSulServerConfig.java
@@ -45,7 +45,7 @@ public class TlsSulServerConfig extends SulServerConfigStandard implements TlsSu
         clone.processDir = getProcessDir();
         // host
         String originalHost = this.getHost();
-        String[] hostParts = originalHost.split(":");
+        String[] hostParts = originalHost.split(":", -1);
         String hostname = hostParts[0];
         int originalPort = Integer.parseInt(hostParts[1]);
         int newPort = originalPort + threadId;


### PR DESCRIPTION
Use the version with two arguments and explicit 'limit' of -1.
(see also https://errorprone.info/bugpattern/StringSplitter)