### PR TITLE
Simplify the setup of Eclipse TinyDTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,9 +229,6 @@ Those in italics are dependencies which `setup_sut.sh` tries to install using `s
     - *m4*
     - *pkg-config*
     - *nettle*
-- Eclipse's TinyDTLS
-    - *m4*
-    - *autoconf*
 - WolfSSL
     - *m4*
     - *autoconf*

--- a/setup_sut.sh
+++ b/setup_sut.sh
@@ -40,9 +40,6 @@ readonly CTINYDTLS_COMMIT="53a0d97"
 readonly ETINYDTLS="etinydtls"
 readonly ETINYDTLS_REP_URL="https://github.com/eclipse/tinydtls.git"
 readonly ETINYDTLS_COMMIT="8414f8a"
-readonly ETINYDTLS_DEVELOP="etinydtls-develop"
-readonly ETINYDTLS_DEVELOP_REP_URL="https://github.com/eclipse/tinydtls.git"
-readonly ETINYDTLS_DEVELOP_COMMIT="19d9fcf"
 
 readonly GNUTLS_LATEST="gnutls-latest"
 readonly GNUTLS_LATEST_REP_URL="https://gitlab.com/gnutls/gnutls.git"
@@ -425,9 +422,6 @@ function install_sut_dep() {
         nettle=$(get_nettle "${sut}")
         nettle_url=$(get_arch_url "${nettle}")
         install_dep "${nettle}" "${nettle_url}"
-    elif [[ ${sut} == etinydtls* ]]; then
-        install_dep "${M4}" "${M4_ARCH_URL}"
-        install_dep "${AUTOCONF}" "${AUTOCONF_ARCH_URL}"
     elif [[ ${sut} == wolfssl* ]]; then
         install_dep "${M4}" "${M4_ARCH_URL}"
         install_dep "${AUTOCONF}" "${AUTOCONF_ARCH_URL}"


### PR DESCRIPTION
There is no need to compile and install `m4` and `autoconf`.