### PR TITLE
Simplify the setup of WolfSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,24 +222,20 @@ Also, in case of building failure, the source code of the implementation should 
 A workaround is to build the implementation manually.
 As long as the implementation is built, our setup should work.
 
-We hereby give an incomplete tree of dependencies the various SUTs have.
+We hereby give an incomplete list of dependencies the various SUTs have.
+
+- Eclipse TinyDLS: m4 autoconf
+- WolfSSL: m4 autoconf libtool
+
 Those in italics are dependencies which `setup_sut.sh` tries to install using `sudo` access.
 
 - GnuTLS:
     - *m4*
     - *pkg-config*
     - *nettle*
-- WolfSSL
-    - *m4*
-    - *autoconf*
-    - libtool
  - nettle
     - *m4*
     - *pkg-config*
- - autoconf
-    - aclocal
-        - automake
-        - autotools-dev
 
 ## Learning an SUT configuration
 We are now ready to learn an SUT configuration.

--- a/setup_sut.sh
+++ b/setup_sut.sh
@@ -422,10 +422,6 @@ function install_sut_dep() {
         nettle=$(get_nettle "${sut}")
         nettle_url=$(get_arch_url "${nettle}")
         install_dep "${nettle}" "${nettle_url}"
-    elif [[ ${sut} == wolfssl* ]]; then
-        install_dep "${M4}" "${M4_ARCH_URL}"
-        install_dep "${AUTOCONF}" "${AUTOCONF_ARCH_URL}"
-        install_dep "${LIBTOOL}" "${LIBTOOL_ARCH_URL}"
     elif [[ ${sut} == scandium* ]]; then
         if [[ ${sut} == "${SCANDIUM_OLD}" ]]; then
             install_dep "${CALIFORNIUM_OLD}" "${CALIFORNIUM_OLD_ARCH_URL}"


### PR DESCRIPTION
For setting up WolfSSL, there is no need to compile and install `m4`, `autoconf` and `libtool`.  This fixes the error when building `m4` on the CI.